### PR TITLE
fix: add nowait for asyncio disconnect

### DIFF
--- a/fakeredis/aioredis.py
+++ b/fakeredis/aioredis.py
@@ -111,8 +111,8 @@ class FakeConnection(redis_async.Connection):
         self._reader = FakeReader(self._sock)
         self._writer = FakeWriter(self._sock)
 
-    async def disconnect(self, nowait: bool = False):
-        await super().disconnect(nowait=nowait)
+    async def disconnect(self, **kwargs):
+        await super().disconnect(**kwargs)
         self._sock = None
 
     async def can_read(self, timeout: float = 0):

--- a/fakeredis/aioredis.py
+++ b/fakeredis/aioredis.py
@@ -111,8 +111,8 @@ class FakeConnection(redis_async.Connection):
         self._reader = FakeReader(self._sock)
         self._writer = FakeWriter(self._sock)
 
-    async def disconnect(self):
-        await super().disconnect()
+    async def disconnect(self, nowait: bool = False):
+        await super().disconnect(nowait=nowait)
         self._sock = None
 
     async def can_read(self, timeout: float = 0):

--- a/test/test_redis_asyncio.py
+++ b/test/test_redis_asyncio.py
@@ -295,7 +295,7 @@ async def test_async():
     assert x == b"plz"
 
 
-@testtools.run_test_if_redispy_ver('above', '4.4.0rc1')
+@testtools.run_test_if_redispy_ver('above', '4.4.0rc2')
 @pytest.mark.parametrize('nowait', [False, True])
 @pytest.mark.fake
 async def test_connection_disconnect(nowait):

--- a/test/test_redis_asyncio.py
+++ b/test/test_redis_asyncio.py
@@ -295,6 +295,7 @@ async def test_async():
     assert x == b"plz"
 
 
+@testtools.run_test_if_redispy_ver('above', '4.4.0rc1')
 @pytest.mark.parametrize('nowait', [False, True])
 @pytest.mark.fake
 async def test_connection_disconnect(nowait):


### PR DESCRIPTION
please check this.

relative pr https://github.com/redis/redis-py/pull/2356

without this, you can meet this

<details>
<summary>redis/asyncio/connection.py:767: TypeError
</summary>

```py3
    async def send_packed_command(
        self, command: Union[bytes, str, Iterable[bytes]], check_health: bool = True
    ) -> None:
        if not self.is_connected:
            await self.connect()
        elif check_health:
            await self.check_health()
    
        try:
            if isinstance(command, str):
                command = command.encode()
            if isinstance(command, bytes):
                command = [command]
            if self.socket_timeout:
                await asyncio.wait_for(
                    self._send_packed_command(command), self.socket_timeout
                )
            else:
                self._writer.writelines(command)
                await self._writer.drain()
        except asyncio.TimeoutError:
            await self.disconnect(nowait=True)
            raise TimeoutError("Timeout writing to socket") from None
        except OSError as e:
            await self.disconnect(nowait=True)
            if len(e.args) == 1:
                err_no, errmsg = "UNKNOWN", e.args[0]
            else:
                err_no = e.args[0]
                errmsg = e.args[1]
            raise ConnectionError(
                f"Error {err_no} while writing to socket. {errmsg}."
            ) from e
        except Exception:
>           await self.disconnect(nowait=True)
E           TypeError: FakeConnection.disconnect() got an unexpected keyword argument 'nowait'
```


</details>