### PR TITLE
Fix json mget when dict is returned

### DIFF
--- a/fakeredis/stack/_json_mixin.py
+++ b/fakeredis/stack/_json_mixin.py
@@ -171,7 +171,7 @@ class JSONCommandsMixin:
         keys = [CommandItem(key, self._db, item=self._db.get(key), default=[])
                 for key in args[:-1]]
 
-        result = [self._get_single(key, path_str, empty_list_as_none=True) for key in keys]
+        result = [JSONObject.encode(self._get_single(key, path_str, empty_list_as_none=True)) for key in keys]
         return result
 
     @command(name="JSON.CLEAR", fixed=(Key(),), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)

--- a/test/test_json/test_json.py
+++ b/test/test_json/test_json.py
@@ -136,15 +136,17 @@ def test_jsonmget(r: redis.Redis):
     # Test mget with multi paths
     r.json().set("doc1", "$", {"a": 1, "b": 2, "nested": {"a": 3}, "c": None, "nested2": {"a": None}})
     r.json().set("doc2", "$", {"a": 4, "b": 5, "nested": {"a": 6}, "c": None, "nested2": {"a": [None]}})
+    r.json().set("doc3", "$", {"a": 5, "b": 5, "nested": {"a": 8}, "c": None, "nested2": {"a": {"b": "nested3"}}})
     # Compare also to single JSON.GET
     assert r.json().get("doc1", Path("$..a")) == [1, 3, None]
     assert r.json().get("doc2", "$..a") == [4, 6, [None]]
+    assert r.json().get("doc3", "$..a") == [5, 8, {"b": "nested3"}]
 
     # Test mget with single path
     assert r.json().mget(["doc1"], "$..a") == [[1, 3, None]]
 
     # Test mget with multi path
-    assert r.json().mget(["doc1", "doc2"], "$..a") == [[1, 3, None], [4, 6, [None]]]
+    assert r.json().mget(["doc1", "doc2", "doc3"], "$..a") == [[1, 3, None], [4, 6, [None]], [5, 8, {"b": "nested3"}]]
 
     # Test missing key
     assert r.json().mget(["doc1", "missing_doc"], "$..a") == [[1, 3, None], None]


### PR DESCRIPTION
Fix AssertionError in _run_command when mget returns a dict within the list of results.

Can be reproduced by running this script. I would expect the output to be `[[5, 8, {"b": "nested3"}]]`.
```import fakeredis

r = fakeredis.FakeStrictRedis(version=7)
r.json().set(
    "doc3", "$", {
        "a": 5,
        "b": 5,
        "nested": {
            "a": 8
        },
        "c": None,
        "nested2": {
            "a": {
                "b": "nested3"
            }
        }
    })

print(r.json().mget(["doc3"], "$..a"))
```

This is my first PR so please don't be to harsh. :)