### PR TITLE
fix: properly export

### DIFF
--- a/fakeredis/__init__.py
+++ b/fakeredis/__init__.py
@@ -1,7 +1,10 @@
-from ._server import FakeServer, FakeRedis, FakeStrictRedis, FakeConnection, FakeRedisConnSingleton  # noqa: F401
+from ._server import FakeServer, FakeRedis, FakeStrictRedis, FakeConnection, FakeRedisConnSingleton
 
 try:
     from importlib import metadata
 except ImportError:  # for Python<3.8
     import importlib_metadata as metadata  # type: ignore
 __version__ = metadata.version("fakeredis")
+
+
+__all__ = ["FakeServer", "FakeRedis", "FakeStrictRedis", "FakeConnection", "FakeRedisConnSingleton"]


### PR DESCRIPTION
Fixes https://github.com/cunla/fakeredis-py/issues/115

There is a good explanation of the issue here: https://github.com/unionai-oss/pandera/pull/686

TLDR; Pylance/Pyright uses `__all__` as a indicator of public exports.