### PR TITLE
Include tests in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ classifiers = [
 homepage = "https://github.com/cunla/fakeredis-py"
 repository = "https://github.com/cunla/fakeredis-py"
 documentation = "https://fakeredis.readthedocs.io/"
+include = [
+     { path = "test", format = "sdist" },
+]
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
Include the test suite in sdist archives, in order to make it possible for distribution packagers to use them rather than generated GitHub archives.