### PR TITLE
Fix import used in GenericCommandsMixin.randomkey

### DIFF
--- a/fakeredis/commands_mixins/generic_mixin.py
+++ b/fakeredis/commands_mixins/generic_mixin.py
@@ -1,6 +1,6 @@
 import hashlib
 import pickle
-from random import random
+import random
 
 from fakeredis import _msgs as msgs
 from fakeredis._command_args_parsing import extract_args

--- a/test/test_mixins/test_generic_commands.py
+++ b/test/test_mixins/test_generic_commands.py
@@ -459,6 +459,17 @@ def test_pttl_should_return_minus_two_for_non_existent_key(r):
     assert r.pttl('foo') == -2
 
 
+def test_randomkey_returns_none_on_empty_db(r):
+    assert r.randomkey() is None
+
+
+def test_randomkey_returns_existing_key(r):
+    r.set("foo", 1)
+    r.set("bar", 2)
+    r.set("baz", 3)
+    assert r.randomkey().decode() in ("foo", "bar", "baz")
+
+
 def test_persist(r):
     r.set('foo', 'bar', ex=20)
     assert r.persist('foo') == 1


### PR DESCRIPTION
# Purpose
Fix a module import used un `GenericCommandsMixin.randomkey`

# Issue
When executing the `RANDOMKEY` command with `FakeRedis`, an exception is thrown.
`AttributeError: 'builtin_function_or_method' object has no attribute 'choice'`

This issue was introduced in `v1.10.0`

## Steps to reproduce

Execute the `.randomkey()` method (or command) using `FakeRedis`

Assume this `pytest` test
```py
def test_randomkey_returns_existing_key(r):
    # populate db
    r.set("foo", 1)
    r.set("bar", 2)
    r.set("baz", 3)

    # request random key
    assert r.randomkey() in ("foo", "bar", "baz")  # boom!
```