### PR TITLE
fix: use same server_key within pipeline when issued `watch`

### DIFF
--- a/test/test_mixins/test_transactions_commands.py
+++ b/test/test_mixins/test_transactions_commands.py
@@ -307,3 +307,16 @@ def test_socket_cleanup_watch(fake_server):
         sock = pipeline.connection._sock  # noqa: F841
         pipeline.connection.disconnect()
     r2.set('test', 'foo')
+
+def test_get_within_pipeline():
+    from fakeredis import FakeRedis
+
+    fake_redis = FakeRedis()
+    fake_redis.set("test", "foo")
+    fake_redis.set("test2", "foo2")
+    expected_keys = set(fake_redis.keys())
+    with fake_redis.pipeline() as p:
+        assert set(fake_redis.keys()) == expected_keys
+        p.watch("test")
+        assert set(fake_redis.keys()) == expected_keys
+


### PR DESCRIPTION
#212 

This PR introduces two changes:
1. If host/port/db are provided as positional arguments (vs. `kwargs`) it will be transferred into `kwargs`. Previously, the positional arguments would be ignored in the `connection_pool` kwargs. This could lead to new connections to a new `FakeServer` instead of the current one, such as within a pipeline after issuing the `.watch()` command.
2. Generating a random host, if not provided, now happens before initializing the `connection_pool`, this way new connections from the pool will connect to the same `FakeServer`.