### PR TITLE
Implement BITFIELD

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -5,6 +5,12 @@ description: Change log of all fakeredis releases
 
 ## Next release
 
+## v2.20.0
+
+### 🚀 Features
+
+- Implement BITFIELD command
+
 ## v2.19.0
 
 ### 🚀 Features

--- a/docs/redis-commands/Redis.md
+++ b/docs/redis-commands/Redis.md
@@ -619,11 +619,15 @@ Closes the connection.
 Resets the connection.
 
 
-## `bitmap` commands (5/7 implemented)
+## `bitmap` commands (6/7 implemented)
 
 ### [BITCOUNT](https://redis.io/commands/bitcount/)
 
 Counts the number of set bits (population counting) in a string.
+
+#### [BITFIELD](https://redis.io/commands/bitfield/)
+
+Performs arbitrary bitfield integer operations on strings.
 
 ### [BITOP](https://redis.io/commands/bitop/)
 
@@ -643,11 +647,7 @@ Sets or clears the bit at offset of the string value. Creates the key if it does
 
 
 ### Unsupported bitmap commands 
-> To implement support for a command, see [here](../../guides/implement-command/) 
-
-#### [BITFIELD](https://redis.io/commands/bitfield/) <small>(not implemented)</small>
-
-Performs arbitrary bitfield integer operations on strings.
+> To implement support for a command, see [here](../../guides/implement-command/)
 
 #### [BITFIELD_RO](https://redis.io/commands/bitfield_ro/) <small>(not implemented)</small>
 

--- a/fakeredis/_msgs.py
+++ b/fakeredis/_msgs.py
@@ -97,3 +97,8 @@ FILTER_FULL_MSG = ""
 NONSCALING_FILTERS_CANNOT_EXPAND_MSG = "Nonscaling filters cannot expand"
 ITEM_EXISTS_MSG = "item exists"
 NOT_FOUND_MSG = "not found"
+INVALID_BITFIELD_TYPE = (
+    "ERR Invalid bitfield type. Use something like i16 u8. "
+    "Note that u64 is not supported but i64 is."
+)
+INVALID_OVERFLOW_TYPE = "ERR Invalid OVERFLOW type specified"


### PR DESCRIPTION
One less command missing 😁

Note: this is not the most optional implementation, as writes are written bit by bit, needing up to 64 writes.  However this was done in the name of simplicity, specially considering how messed up is the overflow detection on the original REDIS codebase: https://github.com/redis/redis/blob/unstable/src/bitops.c#L288 (which here is contains a ton of modular arithmetic manipulation in order to make it compatible).