### PR TITLE
Do not share state, by default, for sync or async clients

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -13,7 +13,7 @@ description: Change log of all fakeredis releases
 
 ### 🐛 Bug Fixes
 
-- Connection params are defaulted to be the same between async and sync connections #290
+- Connection params are defaulted to be the same between async and sync connections #297
 - `xinfo_stream` raises exception when stream does not exist #296
 
 ## v2.21.1

--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -7,6 +7,7 @@ import warnings
 import weakref
 from collections import defaultdict
 from typing import Dict, Tuple, Any, List, Optional
+import uuid
 
 import redis
 
@@ -144,7 +145,7 @@ class FakeRedisMixin:
                      ]
         # Convert args => kwargs
         kwargs.update({parameters[i].name: args[i] for i in range(len(args))})
-        kwargs.setdefault("host", "localhost")
+        kwargs.setdefault("host", uuid.uuid4().hex)
         kwds = {
             p.name: kwargs.get(p.name, p.default)
             for ind, p in enumerate(parameters)

--- a/fakeredis/aioredis.py
+++ b/fakeredis/aioredis.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import sys
 from typing import Union, Optional, Any, Callable, Iterable, Tuple, List
+import uuid
 
 from redis import ResponseError
 
@@ -184,7 +185,7 @@ class FakeRedis(redis_async.Redis):
     def __init__(
             self,
             *,
-            host: str = "localhost",
+            host: Optional[str] = None,
             port: int = 6379,
             db: Union[str, int] = 0,
             password: Optional[str] = None,
@@ -206,7 +207,7 @@ class FakeRedis(redis_async.Redis):
         if not connection_pool:
             # Adapted from aioredis
             connection_kwargs = dict(
-                host=host,
+                host=host or uuid.uuid4().hex,
                 port=port,
                 db=db,
                 # Ignoring because AUTH is not implemented

--- a/test/test_asyncredis.py
+++ b/test/test_asyncredis.py
@@ -381,7 +381,7 @@ async def test_init_args():
     await r3.set('bar', 'baz')
 
     assert await r1.get('foo') == b'bar'
-    assert await r5.get('foo') == b'bar'
+    assert await r5.get('foo') is None
     assert sync_r1.get('foo') is None
     assert await r2.get('foo') is None
     assert await r3.get('foo') is None

--- a/test/test_asyncredis.py
+++ b/test/test_asyncredis.py
@@ -382,7 +382,7 @@ async def test_init_args():
 
     assert await r1.get('foo') == b'bar'
     assert await r5.get('foo') == b'bar'
-    assert sync_r1.get('foo') == b'bar'
+    assert sync_r1.get('foo') is None
     assert await r2.get('foo') is None
     assert await r3.get('foo') is None
 


### PR DESCRIPTION
Fix #299. Revert the sync client back to _not_ sharing state by default, and make the async client work in the same way.

Also a quick minor fix of the link in the changelog which was taking users to a PR 299, rather than the PR that fixed issue 299.

Note that some of the _real_ Redis tests were failing for me locally but for seemingly unrelated parts of the code so I wasn't sure if that was just something to do with the Redis server on my local machine. Figured I'd see if they fail in CI before spending any time trying to debug them - if they still fail here I'm happy to address them!


