### PR TITLE
fix:xrevrange to work with exclusive ranges

### DIFF
--- a/fakeredis/_stream.py
+++ b/fakeredis/_stream.py
@@ -433,9 +433,11 @@ class XStream:
             return 0, False
         if from_left:
             ind = bisect.bisect_left(self._ids, entry_key)
+            check_idx = ind
         else:
             ind = bisect.bisect_right(self._ids, entry_key)
-        return ind, (ind < len(self._ids) and self._ids[ind] == entry_key)
+            check_idx = ind - 1
+        return ind, (check_idx < len(self._ids) and self._ids[check_idx] == entry_key)
 
     def find_index_key_as_str(self, entry_key_str: Union[str, bytes]) -> Tuple[int, bool]:
         """Find the closest index to entry_key_str in the stream
@@ -500,7 +502,7 @@ class XStream:
                 return len(self._ids)
             ind, found = self.find_index(elem.value, from_left)
             if found and elem.exclusive:
-                ind += 1
+                ind += 1 if from_left else -1
             return ind
 
         start_ind = _find_index(start)

--- a/test/test_mixins/test_streams_commands.py
+++ b/test/test_mixins/test_streams_commands.py
@@ -206,6 +206,26 @@ def test_xrevrange(r: redis.Redis):
     assert get_ids(results) == [m4]
 
 
+def test_xrevrange_exclusive(r: redis.Redis):
+    stream = "stream"
+    m1, m2, m3, m4 = _add_to_stream(r, stream, 4)
+
+    def _exc(key: bytes) -> bytes:
+        return b"(" + key
+
+    results = r.xrevrange(stream, max=_exc(m4))
+    assert get_ids(results) == [m3, m2, m1]
+
+    results = r.xrevrange(stream, max=_exc(m3), min=m2)
+    assert get_ids(results) == [m2]
+
+    results = r.xrevrange(stream, min=_exc(m3))
+    assert get_ids(results) == [m4]
+
+    results = r.xrevrange(stream, min=_exc(m1))
+    assert get_ids(results) == [m4, m3, m2]
+
+
 def test_xrange(r: redis.Redis):
     m = r.xadd("stream1", {"foo": "bar"})
     assert r.xrange("stream1") == [


### PR DESCRIPTION
[bisect_right](https://docs.python.org/3/library/bisect.html#bisect.bisect_right) has a bit different behaviour than bisect_left. Also code did not account for exclusive indexes from right