### PR TITLE
fix:bug in bitpos function for the clear bit mode

### DIFF
--- a/fakeredis/_commands.py
+++ b/fakeredis/_commands.py
@@ -519,6 +519,14 @@ def delete_keys(*keys: CommandItem) -> int:
             ans += 1
     return ans
 
+def positive_range(start: int, end: int, length: int) -> Tuple[int, int]:
+    # Redis handles negative slightly differently for zrange
+    if start < 0:
+        start = max(0, start + length)
+    if end < 0:
+        end += length
+    end = min(end, length - 1)
+    return start, end + 1
 
 def fix_range(start: int, end: int, length: int) -> Tuple[int, int]:
     # Redis handles negative slightly differently for zrange

--- a/fakeredis/_commands.py
+++ b/fakeredis/_commands.py
@@ -519,14 +519,6 @@ def delete_keys(*keys: CommandItem) -> int:
             ans += 1
     return ans
 
-def positive_range(start: int, end: int, length: int) -> Tuple[int, int]:
-    # Redis handles negative slightly differently for zrange
-    if start < 0:
-        start = max(0, start + length)
-    if end < 0:
-        end += length
-    end = min(end, length - 1)
-    return start, end + 1
 
 def fix_range(start: int, end: int, length: int) -> Tuple[int, int]:
     # Redis handles negative slightly differently for zrange

--- a/fakeredis/commands_mixins/bitmap_mixin.py
+++ b/fakeredis/commands_mixins/bitmap_mixin.py
@@ -10,7 +10,6 @@ from fakeredis._commands import (
     BitValue,
     fix_range_string,
     fix_range,
-    positive_range,
     CommandItem,
 )
 from fakeredis._helpers import SimpleError, casematch
@@ -74,12 +73,12 @@ class BitmapCommandsMixin:
             end = len(key_value) if len(args) <= 1 else Int.decode(args[1])
             length = len(key_value)
 
-        start, end = positive_range(start, end, length)
+        start, end = fix_range(start, end, length)
 
-        if start > end or start >= length:
+        if start == end == -1:
             return -1
 
-        value  = value[start:end] if bit_mode else self._bytes_as_bin_string(key_value[start:end])
+        value = value[start:end] if bit_mode else self._bytes_as_bin_string(key_value[start:end])
         result = value.find(bit_chr)
         if result != -1:
             result += start if bit_mode else (start * 8)

--- a/fakeredis/commands_mixins/bitmap_mixin.py
+++ b/fakeredis/commands_mixins/bitmap_mixin.py
@@ -60,24 +60,15 @@ class BitmapCommandsMixin:
             return -1 if bit == 1 else 0
 
         start = 0 if len(args) == 0 else Int.decode(args[0])
-        bit_chr = str(bit)
-
-        if bit_mode:
-            value = self._bytes_as_bin_string(key.value)
-            end = len(value) if len(args) <= 1 else Int.decode(args[1])
-            length = len(value)
-            start, end = fix_range(start, end, length)
-            value = value[start:end]
-        else:
-            end = len(key.value) if len(args) <= 1 else Int.decode(args[1])
-            length = len(key.value)
-            start, end = fix_range(start, end, length)
-            value = self._bytes_as_bin_string(key.value[start:end])
-
+        source_value = self._bytes_as_bin_string(key.value) if bit_mode else key.value
+        end = len(source_value) if len(args) <= 1 else Int.decode(args[1])
+        length = len(source_value)
+        start, end = fix_range(start, end, length)
         if start == end == -1:
             return -1
+        source_value = source_value[start:end] if bit_mode else self._bytes_as_bin_string(source_value[start:end])
 
-        result = value.find(bit_chr)
+        result = source_value.find(str(bit))
         if result != -1:
             result += start if bit_mode else (start * 8)
         elif bit == 0 and len(args) <= 1:

--- a/test/test_mixins/test_bitmap_commands.py
+++ b/test/test_mixins/test_bitmap_commands.py
@@ -212,7 +212,6 @@ def test_bitpos(r: redis.Redis):
     assert r.bitpos("nokey:bitpos", 1, 1) == -1
 
 
-
 @pytest.mark.min_server("7")
 def test_bitops_mode_redis7(r: redis.Redis):
     key = "key:bitpos"

--- a/test/test_mixins/test_bitmap_commands.py
+++ b/test/test_mixins/test_bitmap_commands.py
@@ -197,7 +197,20 @@ def test_bitpos(r: redis.Redis):
     assert r.bitpos(key, 1, 1) == 8
     r.set(key, b"\x00\x00\x00")
     assert r.bitpos(key, 1) == -1
+    r.set(key, b"\xff\xff\xff")
+    assert r.bitpos(key, 1) == 0
+    assert r.bitpos(key, 1, 1) == 8
+    assert r.bitpos(key, 1, 3) == -1
+    assert r.bitpos(key, 0) == 24
+    assert r.bitpos(key, 0, 1) == 24
+    assert r.bitpos(key, 0, 3) == -1
+    assert r.bitpos(key, 0, 0, -1) == -1
     r.set(key, b"\xff\xf0\x00")
+    assert r.bitpos("nokey:bitpos", 0) == 0
+    assert r.bitpos("nokey:bitpos", 1) == -1
+    assert r.bitpos("nokey:bitpos", 0, 1) == 0
+    assert r.bitpos("nokey:bitpos", 1, 1) == -1
+
 
 
 @pytest.mark.min_server("7")


### PR DESCRIPTION
Hey!  Thanks for the library! :rocket: 

I've recently been testing dragonfly's BITPOS implementation with fakeredis and stumbled upon some bugs in fakeredis's implementation, so I've decided to fix it.  The misbehaving is related to the clear bit mode i.e. when BITPOS command looking for 0 bit.

https://redis.io/docs/latest/commands/bitpos/

> If we look for clear bits (the bit argument is 0) and the string only contains bits set to 1, the function returns the first bit not part of the string on the right. So if the string is three bytes set to the value 0xff the command BITPOS key 0 will return 24, since up to bit 23 all the bits are 1.

> The function considers the right of the string as padded with zeros if you look for clear bits and specify no range or the start argument only.
> 
> However, this behavior changes if you are looking for clear bits and specify a range with both start and end. If a clear bit isn't found in the specified range, the function returns -1 as the user specified a clear range and there are no 0 bits in that range.
> 

This PR fixes this, so for the clear bit mode:
- fakeredis returns the number of bits instead of -1 if it doesn't find 0.
- It returns 0 if the key doesn't exist.