### PR TITLE
support disable_decoding in async read_response

### DIFF
--- a/fakeredis/aioredis.py
+++ b/fakeredis/aioredis.py
@@ -173,6 +173,8 @@ class FakeConnection(FakeBaseConnectionMixin, redis_async.Connection):
             response = await self._reader.read(0) if can_read and self._reader else None
         if isinstance(response, redis_async.ResponseError):
             raise response
+        if kwargs.get("disable_decoding", False):
+            return response
         return self._decode(response)
 
     def repr_pieces(self) -> List[Tuple[str, Any]]:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -115,6 +115,8 @@ async def _req_aioredis2(request) -> redis.asyncio.Redis:
     server_type, server_version = request.getfixturevalue("real_redis_version")
     if request.param != "fake" and not server_version:
         pytest.skip("Redis is not running")
+
+    decode_responses = bool(request.node.get_closest_marker("decode_responses"))
     unsupported_server_types = request.node.get_closest_marker("unsupported_server_types")
     if unsupported_server_types and server_type in unsupported_server_types.args:
         pytest.skip(f"Server type {server_type} is not supported")
@@ -131,9 +133,9 @@ async def _req_aioredis2(request) -> redis.asyncio.Redis:
     fake_server: Optional[fakeredis.FakeServer]
     if request.param == "fake":
         fake_server = request.getfixturevalue("fake_server")
-        ret = fakeredis.FakeAsyncRedis(server=fake_server, lua_modules=lua_modules)
+        ret = fakeredis.FakeAsyncRedis(server=fake_server, lua_modules=lua_modules, decode_responses=decode_responses)
     else:
-        ret = redis.asyncio.Redis(host="localhost", port=6390, db=2)
+        ret = redis.asyncio.Redis(host="localhost", port=6390, db=2, decode_responses=decode_responses)
         fake_server = None
     if not fake_server or fake_server.connected:
         await ret.flushall()

--- a/test/test_asyncredis.py
+++ b/test/test_asyncredis.py
@@ -144,6 +144,17 @@ async def test_syntax_error(async_redis: redis.asyncio.Redis):
         await async_redis.execute_command("get")
 
 
+@pytest.mark.decode_responses
+async def test_never_decode(async_redis: redis.asyncio.Redis):
+    assert async_redis.connection_pool.get_encoder().decode_responses
+
+    await async_redis.execute_command("set", "key", "some ascii")
+    text = await async_redis.execute_command("get", "key")
+    assert isinstance(text, str)
+    bytestr = await async_redis.execute_command("get", "key", NEVER_DECODE=True)
+    assert isinstance(bytestr, bytes)
+
+
 @testtools.run_test_if_lupa
 class TestScripts:
     async def test_no_script_error(self, async_redis: redis.asyncio.Redis):


### PR DESCRIPTION
Mimics the code in the sync method to also skip decoding when requested.

https://github.com/cunla/fakeredis-py/blob/7a1ec28bed4c8f97754312691abd563332612c8d/fakeredis/_connection.py#L67