### PR TITLE
Fix/default auth

### DIFF
--- a/fakeredis/commands_mixins/acl_mixin.py
+++ b/fakeredis/commands_mixins/acl_mixin.py
@@ -94,6 +94,7 @@ class AclCommandsMixin:
         if (username is None or username == b"default") and (password == self._server_config.get(b"requirepass", b"")):
             self._client_info["user"] = "default"
             return OK
+        username = username or b"default"
         if len(args) >= 1 and self._check_user_password(username, password):
             self._client_info["user"] = username.decode()
             return OK

--- a/fakeredis/model/_acl.py
+++ b/fakeredis/model/_acl.py
@@ -347,6 +347,9 @@ class AccessControlList:
     def validate_command(self, username: bytes, client_info: bytes, fields: List[bytes]):
         if username not in self._user_acl:
             return
+        if fields and fields[0].lower() == b"auth":
+            # auth command is always allowed
+            return
         user_acl = self._user_acl[username]
         if not user_acl.enabled:
             raise SimpleError("User disabled")

--- a/fakeredis/model/_acl.py
+++ b/fakeredis/model/_acl.py
@@ -115,7 +115,7 @@ class UserAccessControlList:
 
     def check_password(self, password: Optional[bytes]) -> bool:
         if self._nopass:
-            return True
+            return not password
         if not password:
             return False
         password_hex = hashlib.sha256(password).hexdigest().encode()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -54,6 +54,10 @@ def _fake_server(request, real_server_details: ServerDetails) -> fakeredis.FakeS
 def r(request, create_redis: Callable[[int], redis.Redis]) -> redis.Redis:
     rconn = create_redis(db=2)
     connected = request.node.get_closest_marker("disconnected") is None
+    acls = rconn.acl_list()
+    if not acls:
+        # Create a default user if none exists
+        rconn.acl_setuser("default", enabled=True, nopass=True, commands=["+@all"], keys=["*"], channels=["*"])
     if connected:
         rconn.flushall()
     yield rconn

--- a/test/test_mixins/test_acl_commands.py
+++ b/test/test_mixins/test_acl_commands.py
@@ -68,6 +68,13 @@ def test_auth(r: redis.Redis):
     with pytest.raises(redis.AuthenticationError):
         r.auth(username=username, password="wrong_password")
 
+    # test that user can log in even if the default user is disabled
+    r.acl_setuser(default_username, enabled=False)
+    assert r.auth(username=username, password="strong_password") is True
+
+    r.acl_setuser(default_username, enabled=True)
+    r.auth("", "default")
+
 
 def test_acl_list(r: redis.Redis):
     username = "fakeredis-user"


### PR DESCRIPTION
Hello! 

I found a little inconsistency: When the default user is disabled, fakeredis would not allow to run the `AUTH` command, thus preventing the user to switch accounts. 
While writing the test case, I also noticed a few smaller things and fixed them:
* While redis provides a default account on startup, fakeredis doesn't (95526bfff100138f3bcdb801bb85854337f76147) 
* When the user doesn't specify the username, the default should be used, not `None` (3817f1e3c178efa1b38274dec50fda1b039b0875)
* When a user tries to login with a password even though the ACL is set to `nopass`, redis raises (e651489f8d8ec789b6549519da4d00e83d84f316)
* Always allow `AUTH` (9cddc49492611b17af4b29f4022352b351b91b86)


Hope it helps!