### PR TITLE
fix: Fix `test_tcp_server_started` to close the connection

### DIFF
--- a/test/test_tcp_server/test_connectivity.py
+++ b/test/test_tcp_server/test_connectivity.py
@@ -17,7 +17,7 @@ def test_tcp_server_started():
     t = Thread(target=server.serve_forever, daemon=True)
     t.start()
     time.sleep(0.1)
-    r = redis.Redis(host=server_address[0], port=server_address[1])
-    r.set("foo", "bar")
-    assert r.get("foo") == b"bar"
+    with redis.Redis(host=server_address[0], port=server_address[1]) as r:
+        r.set("foo", "bar")
+        assert r.get("foo") == b"bar"
     server.shutdown()


### PR DESCRIPTION
Fix `test_tcp_server_started` to use a context manager, in order to close the connection to the `TcpFakeServer` when done.  Otherwise, the test relies on GC closing the connection in order for the server thread to finish -- which does not happen with PyPy, and causes `pytest` to hang after running the test suite.