### PR TITLE
Fix for 380 (hincrby removes hash key ttl)

### DIFF
--- a/fakeredis/commands_mixins/hash_mixin.py
+++ b/fakeredis/commands_mixins/hash_mixin.py
@@ -58,7 +58,7 @@ class HashCommandsMixin:
         amount = Int.decode(amount_bytes)
         field_value = Int.decode(key.value.get(field, b"0"), decode_error=msgs.INVALID_HASH_MSG)
         c = field_value + amount
-        key.value[field] = self._encodeint(c)
+        key.value.update({field: self._encodeint(c)})
         key.updated()
         return c
 
@@ -68,7 +68,7 @@ class HashCommandsMixin:
         if not math.isfinite(c):
             raise SimpleError(msgs.NONFINITE_MSG)
         encoded = self._encodefloat(c, True)
-        key.value[field] = encoded
+        key.value.update({field: encoded})
         key.updated()
         return encoded
 

--- a/fakeredis/commands_mixins/hash_mixin.py
+++ b/fakeredis/commands_mixins/hash_mixin.py
@@ -24,7 +24,7 @@ class HashCommandsMixin:
     def _hset(self, key: CommandItem, *args: bytes) -> int:
         h = key.value
         keys_count = len(h.keys())
-        h.update(dict(zip(*[iter(args)] * 2)))  # type: ignore  # https://stackoverflow.com/a/12739974/1056460
+        h.update(dict(zip(*[iter(args)] * 2)), clear_expiration=True)  # type: ignore  # https://stackoverflow.com/a/12739974/1056460
         created = len(h.keys()) - keys_count
 
         key.updated()
@@ -58,7 +58,7 @@ class HashCommandsMixin:
         amount = Int.decode(amount_bytes)
         field_value = Int.decode(key.value.get(field, b"0"), decode_error=msgs.INVALID_HASH_MSG)
         c = field_value + amount
-        key.value.update({field: self._encodeint(c)})
+        key.value.update({field: self._encodeint(c)}, clear_expiration=False)
         key.updated()
         return c
 
@@ -68,7 +68,7 @@ class HashCommandsMixin:
         if not math.isfinite(c):
             raise SimpleError(msgs.NONFINITE_MSG)
         encoded = self._encodefloat(c, True)
-        key.value.update({field: encoded})
+        key.value.update({field: encoded}, clear_expiration=False)
         key.updated()
         return encoded
 

--- a/fakeredis/model/_hash.py
+++ b/fakeredis/model/_hash.py
@@ -76,10 +76,11 @@ class Hash:
         self._expire_keys()
         return self._values.items()
 
-    def update(self, values: Dict[bytes, Any]) -> None:
+    def update(self, values: Dict[bytes, Any], clear_expiration: bool) -> None:
         self._expire_keys()
-        for k in values.keys():
-            self.clear_key_expireat(k)
+        if clear_expiration:
+            for k in values.keys():
+                self.clear_key_expireat(k)
         self._values.update(values)
 
     def getall(self) -> Dict[bytes, Any]:

--- a/test/test_mixins/test_hash_commands.py
+++ b/test/test_mixins/test_hash_commands.py
@@ -162,6 +162,13 @@ def test_hincrby_with_no_starting_value(r: redis.Redis):
     assert r.hincrby("foo", "counter") == 3
 
 
+def test_hincrby_with_hash_key_expiration(r: redis.Redis):
+    r.hincrby("foo", "counter")
+    r.hexpire("foo", "counter", 10)
+    assert r.hincrby("foo", "counter") == 2
+    assert r.httl("foo", "counter") >= 0
+
+
 def test_hincrby_with_range_param(r: redis.Redis):
     assert r.hincrby("foo", "counter", 2) == 2
     assert r.hincrby("foo", "counter", 2) == 4
@@ -186,6 +193,12 @@ def test_hincrbyfloat_with_no_starting_value(r: redis.Redis):
     assert r.hincrbyfloat("foo", "counter") == 2.0
     assert r.hincrbyfloat("foo", "counter") == 3.0
 
+
+def test_hincrbyfloat_with_hash_key_expiration(r: redis.Redis):
+    r.hincrbyfloat("foo", "counter", 1.0)
+    r.hexpire("foo", "counter", 10)
+    assert r.hincrbyfloat("foo", "counter", 2.0) == 3.0
+    assert r.httl("foo", "counter") >= 0
 
 def test_hincrbyfloat_with_range_param(r: redis.Redis):
     assert r.hincrbyfloat("foo", "counter", 0.1) == pytest.approx(0.1)

--- a/test/test_mixins/test_hash_commands.py
+++ b/test/test_mixins/test_hash_commands.py
@@ -196,9 +196,13 @@ def test_hincrbyfloat_with_no_starting_value(r: redis.Redis):
 
 def test_hincrbyfloat_with_hash_key_expiration(r: redis.Redis):
     r.hincrbyfloat("foo", "counter", 1.0)
-    r.hexpire("foo", "counter", 10)
+    r.hexpire("foo", 10, "counter")
     assert r.hincrbyfloat("foo", "counter", 2.0) == 3.0
-    assert r.httl("foo", "counter") >= 0
+    res = r.httl("foo", "counter")
+    assert isinstance(res, list)
+    assert len(res) == 1
+    assert res[0] >= 0
+
 
 def test_hincrbyfloat_with_range_param(r: redis.Redis):
     assert r.hincrbyfloat("foo", "counter", 0.1) == pytest.approx(0.1)

--- a/test/test_mixins/test_hash_commands.py
+++ b/test/test_mixins/test_hash_commands.py
@@ -3,12 +3,6 @@ import redis
 import redis.client
 
 from test import testtools
-from test.testtools import raw_command
-
-
-@pytest.mark.min_server("7.4")
-def test_hexpire_empty_key(r: redis.Redis):
-    raw_command(r, "hexpire", b"", 2055010579, "fields", 2, b"\x89U\x04", b"6\x86\xf4\xdd")
 
 
 def test_hstrlen_missing(r: redis.Redis):
@@ -162,16 +156,6 @@ def test_hincrby_with_no_starting_value(r: redis.Redis):
     assert r.hincrby("foo", "counter") == 3
 
 
-def test_hincrby_with_hash_key_expiration(r: redis.Redis):
-    r.hincrby("foo", "counter")
-    r.hexpire("foo", 10, "counter")
-    assert r.hincrby("foo", "counter") == 2
-    res = r.httl("foo", "counter")
-    assert isinstance(res, list)
-    assert len(res) == 1
-    assert res[0] >= 0
-
-
 def test_hincrby_with_range_param(r: redis.Redis):
     assert r.hincrby("foo", "counter", 2) == 2
     assert r.hincrby("foo", "counter", 2) == 4
@@ -195,16 +179,6 @@ def test_hincrbyfloat_with_no_starting_value(r: redis.Redis):
     assert r.hincrbyfloat("foo", "counter") == 1.0
     assert r.hincrbyfloat("foo", "counter") == 2.0
     assert r.hincrbyfloat("foo", "counter") == 3.0
-
-
-def test_hincrbyfloat_with_hash_key_expiration(r: redis.Redis):
-    r.hincrbyfloat("foo", "counter", 1.0)
-    r.hexpire("foo", 10, "counter")
-    assert r.hincrbyfloat("foo", "counter", 2.0) == 3.0
-    res = r.httl("foo", "counter")
-    assert isinstance(res, list)
-    assert len(res) == 1
-    assert res[0] >= 0
 
 
 def test_hincrbyfloat_with_range_param(r: redis.Redis):

--- a/test/test_mixins/test_hash_commands.py
+++ b/test/test_mixins/test_hash_commands.py
@@ -164,9 +164,12 @@ def test_hincrby_with_no_starting_value(r: redis.Redis):
 
 def test_hincrby_with_hash_key_expiration(r: redis.Redis):
     r.hincrby("foo", "counter")
-    r.hexpire("foo", "counter", 10)
+    r.hexpire("foo", 10, "counter")
     assert r.hincrby("foo", "counter") == 2
-    assert r.httl("foo", "counter") >= 0
+    res = r.httl("foo", "counter")
+    assert isinstance(res, list)
+    assert len(res) == 1
+    assert res[0] >= 0
 
 
 def test_hincrby_with_range_param(r: redis.Redis):


### PR DESCRIPTION
Fix for [issue](https://github.com/cunla/fakeredis-py/issues/380): `hincrby` / `hincrbyfloat` commands now don't remove ttl from hash key.