### PR TITLE
Update test dependency on pytest-asyncio to v1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ test = [
     "pytest~=8.3 ; python_version >= '3.9'",
     "hypothesis~=6.111 ; python_version >= '3.9'",
     "pytest-timeout>=2.3.1,<3 ; python_version >= '3.9'",
-    "pytest-asyncio>=0.24,<0.25 ; python_version >= '3.9'",
+    "pytest-asyncio>=1,<2 ; python_version >= '3.9'",
     "pytest-cov~=6.0 ; python_version >= '3.9'",
     "pytest-mock~=3.14 ; python_version >= '3.9'",
     "pytest-html~=4.1 ; python_version >= '3.9'",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,7 +21,7 @@ def _check_lua_module_supported() -> bool:
         return False
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def real_server_details() -> ServerDetails:
     """Returns server's version or exit if server is not running"""
     client = None

--- a/uv.lock
+++ b/uv.lock
@@ -47,6 +47,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -503,7 +512,7 @@ test = [
     { name = "coverage", marker = "python_full_version >= '3.9'", specifier = "~=7.6" },
     { name = "hypothesis", marker = "python_full_version >= '3.9'", specifier = "~=6.111" },
     { name = "pytest", marker = "python_full_version >= '3.9'", specifier = "~=8.3" },
-    { name = "pytest-asyncio", marker = "python_full_version >= '3.9'", specifier = ">=0.24,<0.25" },
+    { name = "pytest-asyncio", marker = "python_full_version >= '3.9'", specifier = ">=1,<2" },
     { name = "pytest-cov", marker = "python_full_version >= '3.9'", specifier = "~=6.0" },
     { name = "pytest-html", marker = "python_full_version >= '3.9'", specifier = "~=4.1" },
     { name = "pytest-mock", marker = "python_full_version >= '3.9'", specifier = "~=3.14" },
@@ -982,14 +991,16 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.24.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
     { name = "pytest", marker = "python_full_version >= '3.9'" },
+    { name = "typing-extensions", version = "4.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/6d/c6cf50ce320cf8611df7a1254d86233b3df7cc07f9b5f5cbcb82e08aa534/pytest_asyncio-0.24.0.tar.gz", hash = "sha256:d081d828e576d85f875399194281e92bf8a68d60d72d1a2faf2feddb6c46b276", size = 49855, upload-time = "2024-08-22T08:03:18.145Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/31/6607dab48616902f76885dfcf62c08d929796fc3b2d2318faf9fd54dbed9/pytest_asyncio-0.24.0-py3-none-any.whl", hash = "sha256:a811296ed596b69bf0b6f3dc40f83bcaf341b155a269052d82efa2b25ac7037b", size = 18024, upload-time = "2024-08-22T08:03:15.536Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR replaces the use of the `@pytest_asyncio.fixture` decorator with `@pytest.fixture` and bumps the dependency on pytest-asyncio to v1.1.0.

Closes #403 