### PR TITLE
fix(timeseries): parse TS.MRANGE label filters with IN-list and - correctly

### DIFF
--- a/fakeredis/stack/_timeseries_mixin.py
+++ b/fakeredis/stack/_timeseries_mixin.py
@@ -27,21 +27,21 @@ class TimeSeriesCommandsMixin:  # TimeSeries commands
             if len(filter_expression.split(b"!=")) != 2:
                 raise SimpleError(msgs.TIMESERIES_BAD_FILTER_EXPRESSION)
             label, value = filter_expression.split(b"!=")
-            if value == "-":
+            if value == b"-":
                 return label in ts.labels
 
-            if value[0] == b"(" and value[-1] == b")":
-                values = set(value[1:-1].split(b","))
+            if value.startswith(b"(") and value.endswith(b")"):
+                values = {v.strip() for v in value[1:-1].split(b",") if v}
                 return label in ts.labels and ts.labels[label] not in values
             return label not in ts.labels or ts.labels[label] != value
         if filter_expression.find(b"=") != -1:
             if len(filter_expression.split(b"=")) != 2:
                 raise SimpleError(msgs.TIMESERIES_BAD_FILTER_EXPRESSION)
             label, value = filter_expression.split(b"=")
-            if value == "-":
+            if value == b"-":
                 return label not in ts.labels
-            if value[0] == b"(" and value[-1] == b")":
-                values = set(value[1:-1].split(b","))
+            if value.startswith(b"(") and value.endswith(b")"):
+                values = {v.strip() for v in value[1:-1].split(b",") if v}
                 return label in ts.labels and ts.labels[label] in values
             return label in ts.labels and ts.labels[label] == value
         raise SimpleError(msgs.TIMESERIES_BAD_FILTER_EXPRESSION)


### PR DESCRIPTION
### Current behavior
When using `TS.MRANGE` with an IN-list filter, e.g. `filters=["sensor=(A,C)"]`, fakeredis always returned no results.  
This happens because:
- `value[0]` and `value[-1]` return ints, so comparing them to `b"("` / `b")"` never matched.
- The code compared `"-"` as a `str` against a `bytes` value, so existence filters also failed.

### Expected behavior
`TS.MRANGE` should return all series whose label value matches any in the IN-list. For example, with labels `sensor=A`, `sensor=B`, `sensor=C`, the filter `sensor=(A,C)` should return the series with sensors A and C.

### Enhancement
This change updates `_filter_expression_check` to:
- Compare bytes correctly (`value == b"-"`).
- Detect IN-lists using `value.startswith(b"(")` and `value.endswith(b")")`.
- Split values on commas and strip whitespace.

### Why this is useful
The IN-list filter is part of the official RedisTimeSeries filter syntax and is widely used for querying multiple label values at once. Aligning fakeredis with Redis behavior improves test fidelity and avoids surprises when switching between fakeredis and a real Redis server.
