### PR TITLE
fix: reap TcpFakeServer handler threads on client disconnect

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -22,6 +22,9 @@ toc_depth: 2
   the following transaction, matching real Redis
 - fix: align stream group errors with Redis — `XPENDING` on a missing key or unknown group now raises `NOGROUP` instead
   of returning `0`/an empty array, and neither `XPENDING` nor `XINFO GROUPS` creates the key as a side effect (#532)
+- fix: `TcpFakeServer` now reaps a connection's handler thread when the client disconnects. On the non-blocking socket
+  an empty read was treated as "no data yet" even at EOF, so every client that ever connected left behind a
+  busy-spinning thread and a stale `server.clients` entry
 
 ### 🧰 Maintenance
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -22,9 +22,6 @@ toc_depth: 2
   the following transaction, matching real Redis
 - fix: align stream group errors with Redis — `XPENDING` on a missing key or unknown group now raises `NOGROUP` instead
   of returning `0`/an empty array, and neither `XPENDING` nor `XINFO GROUPS` creates the key as a side effect (#532)
-- fix: `TcpFakeServer` now reaps a connection's handler thread when the client disconnects. On the non-blocking socket
-  an empty read was treated as "no data yet" even at EOF, so every client that ever connected left behind a
-  busy-spinning thread and a stale `server.clients` entry
 
 ### 🧰 Maintenance
 

--- a/fakeredis/_tcp_server.py
+++ b/fakeredis/_tcp_server.py
@@ -10,8 +10,8 @@ except ImportError:
     HAS_FCNTL = False
 import logging
 import os
+import select
 import threading
-import time
 from dataclasses import dataclass
 from io import BufferedIOBase
 from itertools import count
@@ -34,6 +34,13 @@ try:
     lua_scripts_supported = True
 except ImportError:
     lua_scripts_supported = False
+
+
+# The handler loop interleaves two event sources: inbound data on the TCP socket and
+# replies the server pushes without a client request (pub/sub messages, blocking-command
+# wakeups). This is the socket poll timeout, so it also bounds how long a pushed reply
+# waits before being written out.
+_POLL_INTERVAL = 0.01
 
 
 def to_bytes(value: Any) -> bytes:
@@ -178,10 +185,27 @@ class TCPFakeRequestHandler(StreamRequestHandler):
 
                 data = self.rfile.readline()
                 if data == b"":
-                    time.sleep(0)
-                else:
-                    self.current_client.get_socket().sendall(data)
+                    # The socket is non-blocking, so an empty read means either "nothing
+                    # available yet" or "the peer closed". readline() only touches the
+                    # socket once its buffer is drained, so select() on the raw socket is
+                    # authoritative at this point: readable yet yielding no bytes is EOF.
+                    # For the same reason readline() must not be gated behind select():
+                    # an earlier read can leave whole commands sitting in the buffer while
+                    # the socket itself has nothing further to report.
+                    readable, _, _ = select.select([self.connection], [], [], _POLL_INTERVAL)
+                    if not readable:
+                        continue
+                    # Data may have arrived between the empty read and select(): either
+                    # this read produces it, or it confirms the peer is gone.
+                    data = self.rfile.readline()
+                    if data == b"":
+                        break
+                self.current_client.get_socket().sendall(data)
 
+            except ConnectionError as e:
+                # The peer reset the connection; there is no socket left to report to.
+                LOGGER.debug(f"!!! {self.client_address[0]} reset: {e}")
+                break
             except Exception as e:
                 LOGGER.debug(f"!!! {self.client_address[0]}: {e}")
                 self.writer.dump(e)

--- a/test/test_tcp_server/test_connectivity.py
+++ b/test/test_tcp_server/test_connectivity.py
@@ -54,6 +54,36 @@ def test_tcp_server_started_protocol_3(tcp_server_address: tuple[str, int]):
         assert r.get("foo") == b"bar"
 
 
+def test_handler_threads_are_reaped_when_clients_disconnect():
+    """Each disconnecting client's handler thread must exit, not park in the read loop."""
+    server = TcpFakeServer(("127.0.0.1", 0))
+    port = server.server_address[1]
+    t = Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    try:
+        time.sleep(0.1)
+        threads_before = threading.active_count()
+
+        for _ in range(10):
+            client = redis.Redis(host="127.0.0.1", port=port)
+            client.ping()
+            client.close()
+            client.connection_pool.disconnect()
+
+        deadline = time.time() + 5.0
+        while time.time() < deadline and threading.active_count() > threads_before:
+            time.sleep(0.05)
+
+        assert threading.active_count() == threads_before, (
+            f"{threading.active_count() - threads_before} handler threads leaked"
+        )
+        assert server.clients == {}
+    finally:
+        server.shutdown()
+        server.server_close()
+        t.join()
+
+
 def test_tcp_server_clean_shutdown():
     """Verify that shutdown() + server_close() leaves no lingering handler threads."""
     port = 19100


### PR DESCRIPTION
## Problem

Every client that connects to a `TcpFakeServer` leaks one busy-spinning handler thread when
it disconnects, along with its `server.clients` entry. `setup()` puts the socket in
non-blocking mode, so `rfile.readline()` returns `b""` both when no data is available yet
and at EOF; `handle()` treated every `b""` as the former and spun on `time.sleep(0)`, so the
loop never broke, `finish()` never ran, and threads accumulated for the server's lifetime.

This is the complement of #474 / #409: `_shutdown_event` retires handler threads when the
whole server stops, but a thread whose own client has gone away still never exits. A
session-scoped `TcpFakeServer` test fixture starves on threads.

Fixes #540

## Solution

- Disambiguate the two meanings of an empty read with `select()`: a socket that `select`
  reports readable yet which yields zero bytes is at EOF, so break. The `select` timeout
  doubles as the loop's poll pacing, replacing the `time.sleep(0)` busy-wait.
- `readline()` is deliberately *not* gated behind `select()` — it drains its buffer before
  touching the socket, so complete commands can be pending while the socket has nothing to
  report. The `select` branch is only reached once the buffer is empty, which is exactly
  where `select` is authoritative.
- A second `readline()` after `select()` returns readable covers data arriving in between:
  it either produces that data or proves EOF.
- `_POLL_INTERVAL = 0.01` because the loop interleaves two event sources — the socket and
  `current_client.can_read()` for server-pushed replies (pub/sub, blocking-command wakeups,
  which arrive with no inbound socket data). It bounds push latency at ~10 ms with no spin.
- Treat `ConnectionError` as the disconnect it is. A peer that resets (RST, e.g. a
  garbage-collected connection) raised `ConnectionResetError` out of `readline()` into the
  generic handler, which wrote the error to the dead socket and double-faulted into a
  `socketserver.handle_error()` traceback.

Noted in passing (pre-existing, adjacent, not changed here): the reuse branch in `setup()`
(`if self.client_address in self.server.clients:`) never assigns `self.writer`, so a reused
address would `AttributeError` in `handle()`. It was reachable precisely *because* leaked
entries were never deleted; now that disconnects clear the registry the branch is dead.

## Proof of Validation

Redis Stack server on `localhost:6390` (`redis/redis-stack-server:latest`), Python 3.14.6,
redis-py 8.1.0.

```
uv run pytest -q                                    4354 passed, 1437 skipped, 6 xfailed, 6 xpassed
uv run pytest -q -m "fake or tcp_server"            2852 passed, 58 skipped, 5 xfailed, 1 xpassed
uv run pytest -q test/test_tcp_server/              12 passed
uv run ruff check fakeredis/ test/                  All checks passed!
uv run ruff format --check <changed files>           2 files already formatted
uv run mypy fakeredis/                              43 errors — same 43 as master, none in _tcp_server.py
```

New test `test_handler_threads_are_reaped_when_clients_disconnect` fails on master with
`AssertionError: 10 handler threads leaked` and passes with the fix.

Probe over the traffic shapes the loop has to keep working for, all reporting 0 leaked
threads and an empty `server.clients` at the end:

```
sync x20 (connect/ping/close):        leaked=0 clients=0
async x10 (AsyncRedis set/get/aclose): leaked=0 clients=0
gc x5 (unclosed clients dropped):      leaked=0 clients=0
pubsub across two connections:         ok
XADD/XREAD:                            ok
state shared across connections:       ok
```
