### PR TITLE
fix(streams): return XAUTOCLAIM's next-scan cursor, 0-0 once the PEL is done

### DIFF
--- a/fakeredis/commands_mixins/streams_mixin.py
+++ b/fakeredis/commands_mixins/streams_mixin.py
@@ -8,7 +8,7 @@ from fakeredis._command_args_parsing import extract_args
 from fakeredis._commands import CommandItem, Int, Key, command
 from fakeredis._helpers import OK, SimpleError, SimpleString, casematch, casematch_any, current_time
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
-from fakeredis.model import StreamEntryKey, StreamGroup, StreamRangeTest, XStream
+from fakeredis.model import StreamGroup, StreamRangeTest, XStream
 
 
 class StreamsCommandsMixin(CommandsMixinBase):
@@ -293,11 +293,11 @@ class StreamsCommandsMixin(CommandsMixinBase):
         if not group:
             raise SimpleError(msgs.XGROUP_GROUP_NOT_FOUND_MSG.format(group_name.decode(), key))
 
-        keys: list[StreamEntryKey] = group.read_pel_msgs(min_idle_ms, start, count)
+        keys, next_key = group.read_pel_msgs(min_idle_ms, start, count)
         msgs_claimed, msgs_removed = group.claim(min_idle_ms, keys, consumer_name, None, False)
 
         res: list[bytes | list[bytes | list[tuple[bytes, list[bytes]]]]] = [
-            max(msgs_claimed).encode() if len(msgs_claimed) > 0 else start,
+            next_key.encode() if next_key is not None else b"0-0",
             [msg.encode() for msg in msgs_claimed] if justid else [stream.format_record(msg) for msg in msgs_claimed],
         ]
         if self.version >= (7,):

--- a/fakeredis/model/_stream.py
+++ b/fakeredis/model/_stream.py
@@ -388,12 +388,18 @@ class StreamGroup:
             res.append(record)
         return res
 
-    def read_pel_msgs(self, min_idle_ms: int, start: bytes, count: int) -> list[StreamEntryKey]:
+    def read_pel_msgs(
+        self, min_idle_ms: int, start: bytes, count: int
+    ) -> tuple[list[StreamEntryKey], StreamEntryKey | None]:
+        """Claimable PEL entries from `start`, plus the entry XAUTOCLAIM should resume its scan at.
+
+        The second element is None once the scan has reached the end of the PEL. XAUTOCLAIM reports
+        that as the 0-0 cursor, which is what ends a caller's `while cursor != "0-0"` loop.
+        """
         start_key = StreamEntryKey.parse_str(start)
         curr_time = current_time()
         msgs = sorted([k for k in self.pel if (curr_time - self.pel[k].time_read >= min_idle_ms) and k >= start_key])
-        count = min(count, len(msgs))
-        return msgs[:count]
+        return msgs[:count], msgs[count] if len(msgs) > count else None
 
 
 class XStream(BaseModel):

--- a/test/test_mixins/test_streams_commands.py
+++ b/test/test_mixins/test_streams_commands.py
@@ -788,6 +788,51 @@ def test_xautoclaim_redis7(r: ClientType):
     assert r.xautoclaim(stream, group, consumer1, min_idle_time=0, start_id=message_id2, justid=True) == [message_id2]
 
 
+@testtools.run_test_if_redispy_ver("gte", "4.4")
+def test_xautoclaim_cursor_is_zero_when_scan_completes(r: ClientType):
+    stream, group = "stream", "group"
+    r.xgroup_create(stream, group, id="0", mkstream=True)
+    add_items(r, stream, 3)
+    r.xreadgroup(group, "consumer1", streams={stream: ">"})
+
+    assert r.xautoclaim(stream, group, "consumer2", min_idle_time=0)[0] == b"0-0"
+
+    # Nothing idle enough to claim still means the scan reached the end of the PEL.
+    assert r.xautoclaim(stream, group, "consumer3", min_idle_time=999999, count=1)[0] == b"0-0"
+
+
+@testtools.run_test_if_redispy_ver("gte", "4.4")
+def test_xautoclaim_cursor_resumes_after_the_returned_window(r: ClientType):
+    stream, group = "stream", "group"
+    r.xgroup_create(stream, group, id="0", mkstream=True)
+    ids = add_items(r, stream, 3)
+    r.xreadgroup(group, "consumer1", streams={stream: ">"})
+
+    # COUNT stopped the scan early, so the cursor is the next entry to scan, not the last claimed.
+    cursor, entries = r.xautoclaim(stream, group, "consumer2", min_idle_time=0, count=1)[:2]
+    assert get_ids(entries) == [ids[0]]
+    assert cursor == ids[1]
+
+
+@testtools.run_test_if_redispy_ver("gte", "4.4")
+def test_xautoclaim_pagination_terminates(r: ClientType):
+    stream, group = "stream", "group"
+    r.xgroup_create(stream, group, id="0", mkstream=True)
+    ids = add_items(r, stream, 5)
+    r.xreadgroup(group, "consumer1", streams={stream: ">"})
+
+    cursor, claimed, rounds = b"0-0", [], 0
+    while rounds < 10:
+        cursor, entries = r.xautoclaim(stream, group, "consumer2", min_idle_time=0, start_id=cursor, count=2)[:2]
+        claimed.extend(get_ids(entries))
+        rounds += 1
+        if cursor == b"0-0":
+            break
+
+    assert cursor == b"0-0"
+    assert claimed == ids
+
+
 @pytest.mark.supported_server_versions(min_redis_ver="7")
 def test_xclaim_trimmed_redis7(r: ClientType):
     # xclaim should not raise an exception if the item is not there


### PR DESCRIPTION
Fixes #545.

`XAUTOCLAIM` returned `max(msgs_claimed)` as its next cursor, so it never returned `0-0` and it pointed at an entry the caller had already handled. `read_pel_msgs` now also reports the entry the scan should resume at, and `XAUTOCLAIM` returns `0-0` when there is none.

Entries skipped by min-idle-time are filtered before the `COUNT` window is taken, so they do not consume the `COUNT` budget and a scan that claims nothing still reports `0-0` — which is what a real server does.

## Tests

Three new tests in `test/test_mixins/test_streams_commands.py`:

- `test_xautoclaim_cursor_is_zero_when_scan_completes` — `0-0` after a full scan, and also when nothing is idle enough to claim;
- `test_xautoclaim_cursor_resumes_after_the_returned_window` — with `COUNT 1` of 3 pending, the cursor is the second entry, not the first;
- `test_xautoclaim_pagination_terminates` — a `COUNT 2` loop over a 5-entry PEL finishes in 3 rounds and claims each entry exactly once.

All three fail on `master` against fakeredis and pass against a real server.

## Verification

The cursor contract was measured on redis 6.2.17, redis 7.4.8, redis 8.8.2, valkey 8.1.8 and valkey 9.1.1, including the edges: whole PEL scanned, `COUNT` truncating the scan, nothing idle enough, `start` past the last pending id, empty PEL, and an entry deleted from the stream. All five agree.

Full suite against redis 8.8: `4149 passed, 332 skipped`. The one failure, `test_xadd_redis__green`, is a pre-existing 1 ms clock race on the real-server arm that fails on unmodified `master` too. `ruff check` and `ruff format` are clean, and `mypy` sits at the repo's existing 47-error baseline, unchanged. The now-unused `StreamEntryKey` import was dropped to keep ruff happy.

## Note on #544

The companion PR for #544 touches the same five lines of `xautoclaim` as this one, so the two conflict textually — deliberately kept as independent PRs so you can merge them in either order. Whichever lands second, I will rebase it; the resolution is mechanical.
