### PR TITLE
test(dragonfly): build the fake server with the Redis version Dragonfly reports

### DIFF
--- a/.github/workflows/test-dragonfly.yml
+++ b/.github/workflows/test-dragonfly.yml
@@ -20,7 +20,7 @@ jobs:
           - "test_stack"
           - "test_async"
           - "test_internals"
-          - "test_transactions.py"
+          - "test_dragonfly"
           - "test_keyspace_notifications.py"
     permissions:
       pull-requests: write
@@ -39,6 +39,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
       - uses: actions/setup-python@v7
         with:
           cache-dependency-path: uv.lock
@@ -47,7 +49,7 @@ jobs:
         env:
           PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
         run: |
-          uv sync --extra json --extra bf --extra lua --extra cf
+          uv sync --all-extras
 
       - name: Test without coverage
         run: |

--- a/fakeredis/server_specific_commands/dragonfly_mixin.py
+++ b/fakeredis/server_specific_commands/dragonfly_mixin.py
@@ -16,9 +16,10 @@ class DragonflyCommandsMixin:
     def saddex(self, key: CommandItem, seconds: int, *members: bytes) -> int:
         val = key.value
         old_size = len(val)
-        new_members = set(members) - set(val)
         expire_at_ms = current_time() + seconds * 1000
-        for member in new_members:
+        # The expiry is applied to every listed member, including ones already in the set
+        # (their existing TTL is refreshed), but only newly added members are counted.
+        for member in members:
             val.set_member_expireat(member, expire_at_ms)
         key.updated()
         return len(val) - old_size

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,7 +28,10 @@ class ServerDetails:
     @property
     def server_version(self) -> VersionType:
         if self.server_type == "dragonfly":
-            return self.dragonfly_version or self.redis_version
+            # Dragonfly's own release numbering (e.g. 1.x) is unrelated to the
+            # Redis version it emulates, so FakeServer must be built with the
+            # Redis-compatible version rather than dragonfly_version.
+            return self.redis_version
         elif self.server_type == "valkey":
             return self.valkey_version or self.redis_version
         return self.redis_version
@@ -83,9 +86,13 @@ def _fake_server(request, real_server_details: ServerDetails) -> fakeredis.FakeS
 
 
 @pytest_asyncio.fixture(name="tcp_server_address")
-def _tcp_fake_server() -> Generator[tuple[str, int], Any, None]:
+def _tcp_fake_server(real_server_details: ServerDetails) -> Generator[tuple[str, int], Any, None]:
     server_address = ("127.0.0.1", TCP_SERVER_TEST_PORT)
-    server = TcpFakeServer(server_address)
+    server = TcpFakeServer(
+        server_address,
+        server_type=real_server_details.server_type,
+        server_version=real_server_details.server_version,
+    )
     t = Thread(target=server.serve_forever, daemon=True)
     t.start()
     time.sleep(0.1)

--- a/test/test_dragonfly/test_saddex.py
+++ b/test/test_dragonfly/test_saddex.py
@@ -28,6 +28,8 @@ def test_saddex_expire_members(r: ClientType):
     set_name = "foo"
     assert testtools.raw_command(r, "saddex", set_name, 1, "m1", "m2") == 2
     assert r.sadd(set_name, "m3", "m4") == 2
+    # SADDEX returns only the number of newly added members, but it still applies the
+    # expiry to members that were already in the set, so m3 expires along with m1/m2.
     assert testtools.raw_command(r, "saddex", set_name, 1, "m3") == 0
     sleep(1.1)
-    assert set(r.smembers("foo")) == {b"m3", b"m4"}
+    assert set(r.smembers("foo")) == {b"m4"}

--- a/test/test_keyspace_notifications.py
+++ b/test/test_keyspace_notifications.py
@@ -1,7 +1,12 @@
 import time
 
+import pytest
 import redis
 from redis.client import PubSub
+
+# Dragonfly implements only the `Ex` event class (expired keyevents), enabled with the
+# `--notify_keyspace_events=Ex` startup flag; `CONFIG SET notify-keyspace-events` always fails there.
+pytestmark = pytest.mark.unsupported_server_types("dragonfly")
 
 
 def wait_for_message(pubsub: PubSub, timeout=0.5, ignore_subscribe_messages=False):


### PR DESCRIPTION
`ServerDetails.server_version` preferred `dragonfly_version` -- Dragonfly's own
release number, currently 1.x -- over `redis_version`, the Redis-compatible
version it reports. Every `FakeServer` built for a Dragonfly run therefore
behaved like an ancient Redis for the ~35 `self.version >= (7,)` checks spread
through the mixins, failing a long tail of tests that have nothing to do with
Dragonfly. It now always reports the Redis-compatible version; code that needs
to tell Dragonfly apart gates on `server_type` instead.

Alongside that:

* `TcpFakeServer` is handed the server type and version under test, so the
  `tcp_server` tests exercise the same emulation as the rest of the suite.
* `test_keyspace_notifications.py` is skipped on Dragonfly, which implements
  only the `Ex` event class (via a startup flag -- `CONFIG SET
  notify-keyspace-events` always fails there).
* SADDEX applies its expiry to every listed member, refreshing the TTL of ones
  already in the set, rather than only to newly added members.
* The workflow's stale `test_transactions.py` matrix entry -- a path that does
  not exist -- is replaced by `test_dragonfly`, and it installs uv rather than
  relying on it being present, with all extras so the stack tests can run.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!--STACK-->
### This PR is part of a stack

`#373` split into twelve reviewable pieces. Each branches off the one above it, so they
merge in order; the diff shown here is only this step's own changes.

| PR | Branch | What it covers |
|---|--------|----------------|
| #553 | `df/01-prep` | Server-agnostic fixes: SMOVE, BITCOUNT, GEO ordering, shared zset reply shaping |
| #554 | `df/02-harness` | Build `FakeServer` with the Redis version Dragonfly reports; TCP server + CI plumbing |
| #555 | `df/03-errors` | Error wording and argument validation |
| #556 | `df/04-limits` | Expiry horizon, hash-field TTL cap, 256MB value cap |
| #557 | `df/05-reply-shapes` | Doubles, timed-out blocking pops, sorted-set reply shapes |
| #558 | `df/06-streams` | XREAD/XREADGROUP/XINFO/XPENDING replies |
| #559 | `df/07-pubsub` | Shard and plain channels in one namespace |
| #560 | `df/08-sort-copy-geo` | SORT patterns, COPY without DB, GEO ordering |
| #561 | `df/09-transactions` | WATCH invalidation and MULTI queueing |
| #562 | `df/10-scripting` | Lua 5.4 semantics and script error wording |
| #563 | `df/11-json` | Dragonfly's own JSON implementation |
| #564 | `df/12-hypothesis-docs` | Hypothesis guards + `docs/dragonfly-support.md` |

Verified against a real Dragonfly (`df-v1.40.1`) and a real Redis (`8.4.0`, all modules loaded): every
branch in the stack has an identical failure set to `master`, and the tip of the stack has two
*fewer* failures than `master` (PR #559 repairs a pre-existing pub/sub subscription leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
