### PR TITLE
feat(dragonfly): match its error wording and argument validation

### DIFF
--- a/.github/workflows/test-dragonfly.yml
+++ b/.github/workflows/test-dragonfly.yml
@@ -21,6 +21,7 @@ jobs:
           - "test_async"
           - "test_internals"
           - "test_dragonfly"
+          - "test_tcp_server"
           - "test_keyspace_notifications.py"
     permissions:
       pull-requests: write

--- a/fakeredis/_basefakesocket.py
+++ b/fakeredis/_basefakesocket.py
@@ -227,18 +227,30 @@ class BaseFakeSocket:
         self._db = None
         self.responses = None
 
-    @staticmethod
-    def _extract_line(buf: bytes) -> tuple[bytes, bytes]:
+    def _unknown_command(self, command: str, args: str | None = None) -> SimpleError:
+        """Build the server's "unknown command" error.
+
+        Dragonfly uses its own wording and never echoes the arguments back, so `args` is
+        only appended for the Redis/Valkey format.
+        """
+        if self._server.server_type == "dragonfly":
+            return SimpleError(msgs.DRAGONFLY_UNKNOWN_COMMAND_MSG.format(command.upper()))
+        msg = msgs.UNKNOWN_COMMAND_MSG.format(command)
+        if args is not None:
+            msg += f"'{args}' "
+        return SimpleError(msg)
+
+    def _extract_line(self, buf: bytes) -> tuple[bytes, bytes]:
         pos = buf.find(b"\n") + 1
         if pos <= 0:
-            raise SimpleError(msgs.UNKNOWN_COMMAND_MSG.format(buf.decode().strip()))
+            raise self._unknown_command(buf.decode().strip())
         line = buf[:pos]
         buf = buf[pos:]
         if not line.endswith(b"\r\n"):
             parts = line.decode().strip().split(" ", 1)
             command = parts[0]
             args = parts[1] if len(parts) > 1 else ""
-            raise SimpleError(msgs.UNKNOWN_COMMAND_MSG.format(command) + f"'{args}' ")
+            raise self._unknown_command(command, args)
         return line, buf
 
     def _parse_commands(self) -> Generator[None, Any, None]:
@@ -253,7 +265,7 @@ class BaseFakeSocket:
                 buf += yield
             line, buf = self._extract_line(buf)
             if not line[:1] == b"*":  # array
-                raise SimpleError(msgs.UNKNOWN_COMMAND_MSG.format(buf.decode().strip()))
+                raise self._unknown_command(buf.decode().strip())
             n_fields = int(line[1:-2])
             fields = []
             for i in range(n_fields):
@@ -261,7 +273,7 @@ class BaseFakeSocket:
                     buf += yield
                 line, buf = self._extract_line(buf)
                 if line[:1] != b"$":
-                    raise SimpleError(msgs.UNKNOWN_COMMAND_MSG.format(buf.decode().strip()))
+                    raise self._unknown_command(buf.decode().strip())
                 length = int(line[1:-2])
                 while len(buf) < length + 2:
                     buf += yield
@@ -499,12 +511,12 @@ class BaseFakeSocket:
         if cmd_name not in SUPPORTED_COMMANDS:
             # redis remaps \r or \n in an error to ' ' to make it legal protocol
             clean_name = cmd_name.replace("\r", " ").replace("\n", " ")
-            raise SimpleError(msgs.UNKNOWN_COMMAND_MSG.format(clean_name))
+            raise self._unknown_command(clean_name)
         sig = SUPPORTED_COMMANDS[cmd_name]
         if self._server.server_type not in sig.server_types:
             # redis remaps \r or \n in an error to ' ' to make it legal protocol
             clean_name = cmd_name.replace("\r", " ").replace("\n", " ")
-            raise SimpleError(msgs.UNKNOWN_COMMAND_MSG.format(clean_name))
+            raise self._unknown_command(clean_name)
         func = getattr(self, sig.func_name, None)
         return func, sig
 
@@ -547,7 +559,13 @@ class BaseFakeSocket:
         cursor = int(cursor)
         (pattern, _type, count), _ = extract_args(args, ("*match", "*type", "+count"))
         if count is not None and count <= 0:
-            raise SimpleError(msgs.SYNTAX_ERROR_MSG)
+            # Dragonfly reads COUNT as unsigned: a negative one never decodes, while a zero
+            # is accepted and simply falls back to the default batch size.
+            if self._server.server_type != "dragonfly":
+                raise SimpleError(msgs.SYNTAX_ERROR_MSG)
+            if count < 0:
+                raise SimpleError(msgs.INVALID_INT_MSG)
+            count = None
         count = 10 if count is None else count
         data = sorted(keys)
         bits_len = (len(keys) - 1).bit_length()

--- a/fakeredis/_command_args_parsing.py
+++ b/fakeredis/_command_args_parsing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from collections.abc import Sequence
 from typing import Any
 
@@ -142,22 +143,33 @@ def extract_args(
 
 
 def parse_mpop_args(
-    command: str, numkeys: int, args: tuple[bytes, ...], directions: tuple[str, str]
+    command: str, numkeys: int, args: tuple[bytes, ...], directions: tuple[str, str], server_type: str = "redis"
 ) -> tuple[Sequence[bytes], int, bool]:
     """Validate the LMPOP/BLMPOP/ZMPOP/BZMPOP tail: keys, a direction token, optional COUNT.
 
     `args` is ``key [key ...] <directions[0] | directions[1]> [COUNT count]``.
     Returns (keys, count, whether ``directions[0]`` was the chosen direction).
     """
+    is_dragonfly = server_type == "dragonfly"
     if len(args) < 2:  # arity (at least one key + a direction) is checked before numkeys, like real redis
         raise SimpleError(msgs.WRONG_ARGS_MSG6.format(command))
     if numkeys <= 0:
-        raise SimpleError(msgs.NUMKEYS_GREATER_THAN_ZERO_MSG)
+        if not is_dragonfly:
+            raise SimpleError(msgs.NUMKEYS_GREATER_THAN_ZERO_MSG)
+        # Dragonfly reads numkeys as unsigned, so a negative one never decodes.
+        raise SimpleError(msgs.INVALID_INT_MSG if numkeys < 0 else msgs.DRAGONFLY_AT_LEAST_ONE_KEY_MSG)
     (count, first, second), keys = extract_args(
         args, ("+count", *directions), error_on_unexpected=False, left_from_first_unexpected=False
     )
     if len(keys) != numkeys or first == second:  # exactly one direction, and it follows exactly `numkeys` keys
         raise SimpleError(msgs.SYNTAX_ERROR_MSG)
     if count is not None and count <= 0:
-        raise SimpleError(msgs.COUNT_GREATER_THAN_ZERO_MSG)
+        if not is_dragonfly:
+            raise SimpleError(msgs.COUNT_GREATER_THAN_ZERO_MSG)
+        # Dragonfly accepts COUNT 0 and simply pops nothing. A negative count is read as
+        # unsigned by ZMPOP -- popping everything -- but rejected outright by LMPOP.
+        if count < 0:
+            if command.lower().endswith("lmpop"):
+                raise SimpleError(msgs.INVALID_INT_MSG)
+            count = sys.maxsize
     return keys, 1 if count is None else count, first

--- a/fakeredis/_command_args_parsing.py
+++ b/fakeredis/_command_args_parsing.py
@@ -150,11 +150,10 @@ def parse_mpop_args(
     `args` is ``key [key ...] <directions[0] | directions[1]> [COUNT count]``.
     Returns (keys, count, whether ``directions[0]`` was the chosen direction).
     """
-    is_dragonfly = server_type == "dragonfly"
     if len(args) < 2:  # arity (at least one key + a direction) is checked before numkeys, like real redis
         raise SimpleError(msgs.WRONG_ARGS_MSG6.format(command))
     if numkeys <= 0:
-        if not is_dragonfly:
+        if server_type != "dragonfly":
             raise SimpleError(msgs.NUMKEYS_GREATER_THAN_ZERO_MSG)
         # Dragonfly reads numkeys as unsigned, so a negative one never decodes.
         raise SimpleError(msgs.INVALID_INT_MSG if numkeys < 0 else msgs.DRAGONFLY_AT_LEAST_ONE_KEY_MSG)
@@ -164,10 +163,10 @@ def parse_mpop_args(
     if len(keys) != numkeys or first == second:  # exactly one direction, and it follows exactly `numkeys` keys
         raise SimpleError(msgs.SYNTAX_ERROR_MSG)
     if count is not None and count <= 0:
-        if not is_dragonfly:
+        if server_type != "dragonfly":
             raise SimpleError(msgs.COUNT_GREATER_THAN_ZERO_MSG)
-        # Dragonfly accepts COUNT 0 and simply pops nothing. A negative count is read as
-        # unsigned by ZMPOP -- popping everything -- but rejected outright by LMPOP.
+        # Dragonfly accepts COUNT 0 and simply pops nothing. A negative count is read as unsigned by ZMPOP --
+        # popping everything -- but rejected outright by LMPOP.
         if count < 0:
             if command.lower().endswith("lmpop"):
                 raise SimpleError(msgs.INVALID_INT_MSG)

--- a/fakeredis/_msgs.py
+++ b/fakeredis/_msgs.py
@@ -39,6 +39,12 @@ ZUNIONSTORE_KEYS_MSG = "ERR at least 1 input key is needed for {}"
 WRONG_ARGS_MSG7 = "ERR Wrong number of args calling Redis command from script"
 WRONG_ARGS_MSG6 = "ERR wrong number of arguments for '{}' command"
 UNKNOWN_COMMAND_MSG = "ERR unknown command '{}', with args beginning with: "
+# Dragonfly reports unknown commands in its own format, without echoing the arguments back.
+DRAGONFLY_UNKNOWN_COMMAND_MSG = "ERR unknown command `{}`"
+# Dragonfly's wording for the SINTERCARD/ZINTERCARD LIMIT and numkeys checks.
+DRAGONFLY_LIMIT_NEGATIVE_MSG = "ERR limit can't be negative"
+DRAGONFLY_LIMIT_NOT_POSITIVE_MSG = "ERR limit value is not a positive integer"
+DRAGONFLY_AT_LEAST_ONE_KEY_MSG = "ERR at least 1 input key is needed for this command"
 EXECABORT_MSG = "EXECABORT Transaction discarded because of previous errors."
 MULTI_NESTED_MSG = "ERR MULTI calls can not be nested"
 WITHOUT_MULTI_MSG = "ERR {0} without MULTI"

--- a/fakeredis/commands_mixins/list_mixin.py
+++ b/fakeredis/commands_mixins/list_mixin.py
@@ -175,16 +175,19 @@ class ListCommandsMixin(CommandsMixinBase):
             res = _list_pop_count(op, item, count)
             if res:
                 return [key, res]
+            # Dragonfly allows COUNT 0, which names the first existing key but pops nothing.
+            if count == 0 and item.value and self.server_type == "dragonfly":
+                return [key, []]
         return None
 
     @command(fixed=(Int,), repeat=(bytes,))
     def lmpop(self, numkeys: int, *args: bytes) -> list[Any] | None:
-        keys, count, left = parse_mpop_args("lmpop", numkeys, args, ("left", "right"))
+        keys, count, left = parse_mpop_args("lmpop", numkeys, args, ("left", "right"), self.server_type)
         return self._lmpop(keys, count, left, False)
 
     @command(fixed=(Timeout, Int), repeat=(bytes,))
     def blmpop(self, timeout: float, numkeys: int, *args: bytes) -> Any:
-        keys, count, left = parse_mpop_args("blmpop", numkeys, args, ("left", "right"))
+        keys, count, left = parse_mpop_args("blmpop", numkeys, args, ("left", "right"), self.server_type)
         return self._blocking(
             timeout,
             functools.partial(self._lmpop, keys, count, left),
@@ -284,12 +287,15 @@ class ListCommandsMixin(CommandsMixinBase):
                 "+maxlen",
             ),
         )
+        # Dragonfly validates these while decoding them, so all three report the generic
+        # integer error rather than naming the offending option.
+        is_dragonfly = self.server_type == "dragonfly"
         if rank == 0:
-            raise SimpleError(msgs.LPOS_RANK_CAN_NOT_BE_ZERO)
+            raise SimpleError(msgs.INVALID_INT_MSG if is_dragonfly else msgs.LPOS_RANK_CAN_NOT_BE_ZERO)
         if count is not None and count < 0:
-            raise SimpleError(msgs.LPOS_COUNT_NEGATIVE_MSG)
+            raise SimpleError(msgs.INVALID_INT_MSG if is_dragonfly else msgs.LPOS_COUNT_NEGATIVE_MSG)
         if maxlen is not None and maxlen < 0:
-            raise SimpleError(msgs.LPOS_MAXLEN_NEGATIVE_MSG)
+            raise SimpleError(msgs.INVALID_INT_MSG if is_dragonfly else msgs.LPOS_MAXLEN_NEGATIVE_MSG)
         rank = rank or 1
         ind, direction = (0, 1) if rank > 0 else (len(key.value) - 1, -1)
         rank = abs(rank)

--- a/fakeredis/commands_mixins/set_mixin.py
+++ b/fakeredis/commands_mixins/set_mixin.py
@@ -76,23 +76,20 @@ class SetCommandsMixin(CommandsMixinBase):
     def sintercard(self, numkeys: int, *args: bytes) -> int:
         if self.version < (7,):
             raise SimpleError(msgs.UNKNOWN_COMMAND_MSG.format("sintercard"))
-        # Dragonfly reports a numkeys that does not match the key list as a plain syntax
-        # error, and lower-cases the LIMIT complaint.
-        is_dragonfly = self.server_type == "dragonfly"
         if numkeys < 1:
-            if not is_dragonfly:
+            if self.server_type != "dragonfly":
                 raise SimpleError(msgs.NUMKEYS_GREATER_THAN_ZERO_MSG)
-            # Dragonfly reads numkeys as unsigned, so a negative one fails to decode while
-            # a zero is rejected by the shared "needs at least one key" check.
             raise SimpleError(msgs.INVALID_INT_MSG if numkeys < 0 else msgs.DRAGONFLY_AT_LEAST_ONE_KEY_MSG)
         limit = 0
         if len(args) >= 2 and casematch(args[-2], b"limit"):
             limit = Int.decode(args[-1])
             if limit < 0:
-                raise SimpleError(msgs.DRAGONFLY_LIMIT_NEGATIVE_MSG if is_dragonfly else msgs.LIMIT_NEGATIVE_MSG)
+                raise SimpleError(
+                    msgs.DRAGONFLY_LIMIT_NEGATIVE_MSG if self.server_type == "dragonfly" else msgs.LIMIT_NEGATIVE_MSG
+                )
             args = args[:-2]
         if numkeys > len(args):
-            raise SimpleError(msgs.SYNTAX_ERROR_MSG if is_dragonfly else msgs.TOO_MANY_KEYS_MSG)
+            raise SimpleError(msgs.SYNTAX_ERROR_MSG if self.server_type == "dragonfly" else msgs.TOO_MANY_KEYS_MSG)
         elif numkeys < len(args):
             raise SimpleError(msgs.SYNTAX_ERROR_MSG)
         keys = [CommandItem(args[i], self._db, item=self._db.get(args[i])) for i in range(numkeys)]

--- a/fakeredis/commands_mixins/set_mixin.py
+++ b/fakeredis/commands_mixins/set_mixin.py
@@ -120,8 +120,9 @@ class SetCommandsMixin(CommandsMixinBase):
     def smove(self, src: CommandItem, dst: CommandItem, member: bytes) -> int:
         src_exists = src.key in self._db
         dst_wrong_type = dst.value is not None and not isinstance(dst.value, ExpiringMembersSet)
-        # Redis only looks at the destination once the source key exists, while dragonfly checks its type up front --
-        # so moving out of a missing set into a string fails there and answers 0 on redis.
+        # Redis only looks at the destination once the source key exists, while dragonfly
+        # checks its type up front -- so moving out of a missing set into a string fails
+        # there and answers 0 on redis.
         if dst_wrong_type and (src_exists or self.server_type == "dragonfly"):
             raise SimpleError(msgs.WRONGTYPE_MSG)
         if not src_exists or member not in src.value:

--- a/fakeredis/commands_mixins/set_mixin.py
+++ b/fakeredis/commands_mixins/set_mixin.py
@@ -76,16 +76,23 @@ class SetCommandsMixin(CommandsMixinBase):
     def sintercard(self, numkeys: int, *args: bytes) -> int:
         if self.version < (7,):
             raise SimpleError(msgs.UNKNOWN_COMMAND_MSG.format("sintercard"))
+        # Dragonfly reports a numkeys that does not match the key list as a plain syntax
+        # error, and lower-cases the LIMIT complaint.
+        is_dragonfly = self.server_type == "dragonfly"
         if numkeys < 1:
-            raise SimpleError(msgs.NUMKEYS_GREATER_THAN_ZERO_MSG)
+            if not is_dragonfly:
+                raise SimpleError(msgs.NUMKEYS_GREATER_THAN_ZERO_MSG)
+            # Dragonfly reads numkeys as unsigned, so a negative one fails to decode while
+            # a zero is rejected by the shared "needs at least one key" check.
+            raise SimpleError(msgs.INVALID_INT_MSG if numkeys < 0 else msgs.DRAGONFLY_AT_LEAST_ONE_KEY_MSG)
         limit = 0
         if len(args) >= 2 and casematch(args[-2], b"limit"):
             limit = Int.decode(args[-1])
             if limit < 0:
-                raise SimpleError(msgs.LIMIT_NEGATIVE_MSG)
+                raise SimpleError(msgs.DRAGONFLY_LIMIT_NEGATIVE_MSG if is_dragonfly else msgs.LIMIT_NEGATIVE_MSG)
             args = args[:-2]
         if numkeys > len(args):
-            raise SimpleError(msgs.TOO_MANY_KEYS_MSG)
+            raise SimpleError(msgs.SYNTAX_ERROR_MSG if is_dragonfly else msgs.TOO_MANY_KEYS_MSG)
         elif numkeys < len(args):
             raise SimpleError(msgs.SYNTAX_ERROR_MSG)
         keys = [CommandItem(args[i], self._db, item=self._db.get(args[i])) for i in range(numkeys)]
@@ -112,9 +119,10 @@ class SetCommandsMixin(CommandsMixinBase):
     @command((Key(ExpiringMembersSet), Key(), bytes))
     def smove(self, src: CommandItem, dst: CommandItem, member: bytes) -> int:
         src_exists = src.key in self._db
-        # The destination is only looked at once the source key exists, so moving out of a missing set into a wrongly
-        # typed key answers 0 rather than failing.
-        if src_exists and dst.value is not None and not isinstance(dst.value, ExpiringMembersSet):
+        dst_wrong_type = dst.value is not None and not isinstance(dst.value, ExpiringMembersSet)
+        # Redis only looks at the destination once the source key exists, while dragonfly checks its type up front --
+        # so moving out of a missing set into a string fails there and answers 0 on redis.
+        if dst_wrong_type and (src_exists or self.server_type == "dragonfly"):
             raise SimpleError(msgs.WRONGTYPE_MSG)
         if not src_exists or member not in src.value:
             return 0
@@ -137,6 +145,10 @@ class SetCommandsMixin(CommandsMixinBase):
             return item  # type: ignore
         else:
             if count < 0:
+                # Dragonfly rejects the negative count while decoding it, so it reports the
+                # generic integer error rather than redis' "must be positive".
+                if self.server_type == "dragonfly":
+                    raise SimpleError(msgs.INVALID_INT_MSG)
                 raise SimpleError(msgs.INDEX_NEGATIVE_ERROR_MSG)
             items: bytes | list[bytes] = self.srandmember(key, count)
             for item in items:

--- a/fakeredis/commands_mixins/sortedset_mixin.py
+++ b/fakeredis/commands_mixins/sortedset_mixin.py
@@ -467,7 +467,11 @@ class SortedSetCommandsMixin(CommandsMixinBase):
 
     def _zunioninterdiff(self, func: str, dest: CommandItem | None, numkeys: int, *args: bytes) -> ZSet | int:
         if numkeys < 1:
-            raise SimpleError(msgs.ZUNIONSTORE_KEYS_MSG.format(func.lower()))
+            if self.server_type != "dragonfly":
+                raise SimpleError(msgs.ZUNIONSTORE_KEYS_MSG.format(func.lower()))
+            # Dragonfly reads numkeys as unsigned, so a negative one never decodes, and it
+            # words the zero case without naming the command.
+            raise SimpleError(msgs.INVALID_INT_MSG if numkeys < 0 else msgs.DRAGONFLY_AT_LEAST_ONE_KEY_MSG)
         if numkeys > len(args):
             raise SimpleError(msgs.SYNTAX_ERROR_MSG)
         aggregate = b"sum"
@@ -585,6 +589,9 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         )
         limit = limit if limit is not None else 0
         if limit < 0:
+            # Dragonfly words the ZINTERCARD limit check differently from the SINTERCARD one.
+            if self.server_type == "dragonfly":
+                raise SimpleError(msgs.DRAGONFLY_LIMIT_NOT_POSITIVE_MSG)
             raise SimpleError(msgs.LIMIT_NEGATIVE_MSG)
         limit = limit if limit != 0 else sys.maxsize
         res = self._zunioninterdiff("ZINTER", None, numkeys, *left_args)
@@ -633,16 +640,19 @@ class SortedSetCommandsMixin(CommandsMixinBase):
             if res:
                 item.writeback()  # remove the key if the set is now empty
                 return [key, res]
+            # Dragonfly allows COUNT 0, which names the first existing key but pops nothing.
+            if count == 0 and item.value and self.server_type == "dragonfly":
+                return [key, []]
         return None
 
     @command(fixed=(Int,), repeat=(bytes,))
     def zmpop(self, numkeys: int, *args: bytes) -> list[Any] | None:
-        keys, count, reverse = parse_mpop_args("zmpop", numkeys, args, ("max", "min"))
+        keys, count, reverse = parse_mpop_args("zmpop", numkeys, args, ("max", "min"), self.server_type)
         return self._zmpop(keys, count, reverse, False)
 
     @command(fixed=(Timeout, Int), repeat=(bytes,))
     def bzmpop(self, timeout: float, numkeys: int, *args: bytes) -> list[Any] | None:
-        keys, count, reverse = parse_mpop_args("bzmpop", numkeys, args, ("max", "min"))
+        keys, count, reverse = parse_mpop_args("bzmpop", numkeys, args, ("max", "min"), self.server_type)
         return self._blocking(  # type: ignore[no-any-return]
             timeout,
             functools.partial(self._zmpop, keys, count, reverse),

--- a/fakeredis/commands_mixins/sortedset_mixin.py
+++ b/fakeredis/commands_mixins/sortedset_mixin.py
@@ -469,8 +469,8 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         if numkeys < 1:
             if self.server_type != "dragonfly":
                 raise SimpleError(msgs.ZUNIONSTORE_KEYS_MSG.format(func.lower()))
-            # Dragonfly reads numkeys as unsigned, so a negative one never decodes, and it
-            # words the zero case without naming the command.
+            # Dragonfly reads numkeys as unsigned, so a negative one never decodes, and it words the zero case without
+            # naming the command.
             raise SimpleError(msgs.INVALID_INT_MSG if numkeys < 0 else msgs.DRAGONFLY_AT_LEAST_ONE_KEY_MSG)
         if numkeys > len(args):
             raise SimpleError(msgs.SYNTAX_ERROR_MSG)

--- a/fakeredis/commands_mixins/string_mixin.py
+++ b/fakeredis/commands_mixins/string_mixin.py
@@ -372,7 +372,7 @@ class StringCommandsMixin(CommandsMixinBase, ABC):
             key.expireat = None if expire_time is None else int(expire_time)
         return key.get(None)
 
-    @command(fixed=(Key(bytes), Key(bytes)), repeat=(bytes,))
+    @command(fixed=(Key(bytes), Key(bytes)), repeat=(bytes,), server_types=("redis", "valkey"))
     def lcs(self, k1: CommandItem, k2: CommandItem, *args: bytes) -> bytes | int | dict[bytes, Any]:
         s1 = k1.value or b""
         s2 = k2.value or b""

--- a/test/test_dragonfly/test_dragonfly_divergences.py
+++ b/test/test_dragonfly/test_dragonfly_divergences.py
@@ -1,0 +1,63 @@
+"""Behaviour where Dragonfly deliberately differs from Redis.
+
+The Redis-flavoured versions of these tests are marked
+`@pytest.mark.unsupported_server_types("dragonfly")` in `test/test_mixins`; these are the
+Dragonfly counterparts, so both sides of each divergence stay covered.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fakeredis._typing import ClientType
+from test.testtools import raw_command
+
+pytestmark = []
+pytestmark.extend(
+    [
+        pytest.mark.unsupported_server_types("redis", "valkey"),
+    ]
+)
+
+RESPONSE_ERRORS = ("redis.exceptions.ResponseError", "valkey.exceptions.ResponseError")
+
+
+def _raises(r: ClientType, match: str, *args):
+    with pytest.raises(Exception, match=match) as ctx:
+        raw_command(r, *args)
+    assert type(ctx.value).__module__ + "." + type(ctx.value).__qualname__ in RESPONSE_ERRORS
+    return ctx.value
+
+
+def test_unknown_command_message_format(r: ClientType):
+    # Dragonfly names the command in backticks and uppercase, and does not echo the args.
+    err = _raises(r, "unknown command", "nosuchcmd", "a", "b")
+    assert str(err) == "unknown command `NOSUCHCMD`"
+
+
+def test_lcs_is_not_supported(r: ClientType):
+    r.mset({"key1": "ohmytext", "key2": "mynewtext"})
+    err = _raises(r, "unknown command", "lcs", "key1", "key2")
+    assert str(err) == "unknown command `LCS`"
+
+
+def test_at_least_one_key_is_needed_for_numkeys_commands(r: ClientType):
+    r.sadd("s", "m")
+    r.zadd("z", {"m": 1.0})
+    for args in (
+        ("sintercard", 0, "s"),
+        ("zintercard", 0, "z"),
+        ("zunion", 0, "z"),
+        ("zunionstore", "dst", 0, "z"),
+    ):
+        _raises(r, "at least 1 input key is needed for this command", *args)
+    # Dragonfly reads numkeys as unsigned, so a negative one never decodes.
+    for args in (("sintercard", -1, "s"), ("zintercard", -1, "z")):
+        _raises(r, "value is not an integer or out of range", *args)
+
+
+def test_smove_checks_the_destination_type_even_when_the_source_is_missing(r: ClientType):
+    r.set("str", "x")
+    _raises(r, "WRONGTYPE", "smove", "nosuchkey", "str", "m")
+    # With both keys missing there is nothing to check, and the answer is 0.
+    assert r.smove("nosuchkey", "alsomissing", "m") is False

--- a/test/test_mixins/test_generic_scan_commands.py
+++ b/test/test_mixins/test_generic_scan_commands.py
@@ -202,16 +202,20 @@ def test_scan_stream(r: ClientType):
         print(s)
 
 
-def test_scan_family_count_not_positive(r: ClientType):
+def test_scan_family_count_not_positive(r: ClientType, real_server_details):
     r.sadd("set", "m")
     r.hset("hash", "f", "v")
     r.zadd("zset", {"m": 1})
+    is_dragonfly = real_server_details.server_type == "dragonfly"
+    commands = (("scan", 0), ("sscan", "set", 0), ("hscan", "hash", 0), ("zscan", "zset", 0))
     for count in (0, -1):
-        with pytest.raises(Exception, match="syntax error"):
-            raw_command(r, "scan", 0, "COUNT", count)
-        with pytest.raises(Exception, match="syntax error"):
-            raw_command(r, "sscan", "set", 0, "COUNT", count)
-        with pytest.raises(Exception, match="syntax error"):
-            raw_command(r, "hscan", "hash", 0, "COUNT", count)
-        with pytest.raises(Exception, match="syntax error"):
-            raw_command(r, "zscan", "zset", 0, "COUNT", count)
+        # Dragonfly reads COUNT as unsigned: 0 is accepted and uses the default batch size,
+        # while a negative value fails to decode.
+        if is_dragonfly and count == 0:
+            for args in commands:
+                raw_command(r, *args, "COUNT", count)
+            continue
+        expected = "value is not an integer or out of range" if is_dragonfly else "syntax error"
+        for args in commands:
+            with pytest.raises(Exception, match=expected):
+                raw_command(r, *args, "COUNT", count)

--- a/test/test_mixins/test_list_commands.py
+++ b/test/test_mixins/test_list_commands.py
@@ -743,8 +743,18 @@ def test_lmpop(r: ClientType):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
-def test_lmpop_count_not_positive(r: ClientType):
+def test_lmpop_count_not_positive(r: ClientType, real_server_details):
     r.rpush("foo", "a", "b")
+    if real_server_details.server_type == "dragonfly":
+        # Dragonfly accepts COUNT 0, naming the key but popping nothing, and reports a
+        # negative count as a plain decoding failure.
+        assert testtools.raw_command(r, "lmpop", 1, "foo", "LEFT", "COUNT", 0) == [b"foo", []]
+        for args in (("lmpop", 1, "foo", "LEFT", "COUNT", -1), ("blmpop", 0.01, 1, "foo", "LEFT", "COUNT", -1)):
+            with pytest.raises(Exception, match="value is not an integer or out of range") as ctx:
+                testtools.raw_command(r, *args)
+            assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
+        assert r.lrange("foo", 0, -1) == [b"a", b"b"]
+        return
     for count in (0, -1):
         with pytest.raises(Exception, match="count should be greater than 0") as ctx:
             testtools.raw_command(r, "lmpop", 1, "foo", "LEFT", "COUNT", count)
@@ -757,10 +767,16 @@ def test_lmpop_count_not_positive(r: ClientType):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
-def test_lmpop_numkeys_not_positive(r: ClientType):
+def test_lmpop_numkeys_not_positive(r: ClientType, real_server_details):
     r.rpush("foo", "a")
+    is_dragonfly = real_server_details.server_type == "dragonfly"
     for numkeys in (0, -1):
-        with pytest.raises(Exception, match="numkeys should be greater than 0") as ctx:
+        # Dragonfly reads numkeys as unsigned, so -1 fails to decode before the key check.
+        if is_dragonfly:
+            expected = "at least 1 input key is needed" if numkeys == 0 else "value is not an integer or out of range"
+        else:
+            expected = "numkeys should be greater than 0"
+        with pytest.raises(Exception, match=expected) as ctx:
             testtools.raw_command(r, "lmpop", numkeys, "foo", "LEFT")
         assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 
@@ -773,12 +789,15 @@ def test_lmpop_too_few_arguments(r: ClientType):
         assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 
 
-def test_lpos_negative_count_or_maxlen(r: ClientType):
+def test_lpos_negative_count_or_maxlen(r: ClientType, real_server_details):
     r.rpush("foo", "a", "b", "a")
-    with pytest.raises(Exception, match="COUNT can't be negative") as ctx:
+    # Dragonfly rejects these while decoding, so it never names the offending option.
+    is_dragonfly = real_server_details.server_type == "dragonfly"
+    generic = "value is not an integer or out of range"
+    with pytest.raises(Exception, match=generic if is_dragonfly else "COUNT can't be negative") as ctx:
         r.lpos("foo", "a", count=-1)
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
-    with pytest.raises(Exception, match="MAXLEN can't be negative") as ctx:
+    with pytest.raises(Exception, match=generic if is_dragonfly else "MAXLEN can't be negative") as ctx:
         r.lpos("foo", "a", count=0, maxlen=-1)
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 

--- a/test/test_mixins/test_set_commands.py
+++ b/test/test_mixins/test_set_commands.py
@@ -424,13 +424,17 @@ def test_sintercard_bytes_keys(r: ClientType):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
-def test_sintercard_negative_limit(r: ClientType):
+def test_sintercard_negative_limit(r: ClientType, real_server_details):
     r.sadd("foo", "member1", "member2")
     r.sadd("bar", "member2", "member3")
     with pytest.raises(Exception) as ctx:
         r.sintercard(2, ["foo", "bar"], limit=-1)
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
-    assert "LIMIT can't be negative" in str(ctx.value)
+    # Dragonfly lower-cases the same complaint.
+    expected = (
+        "limit can't be negative" if real_server_details.server_type == "dragonfly" else "LIMIT can't be negative"
+    )
+    assert expected in str(ctx.value)
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
@@ -532,25 +536,43 @@ def test_psetex_expire_value_using_timedelta(r: ClientType):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
-def test_sintercard_numkeys_not_positive(r: ClientType):
+def test_sintercard_numkeys_not_positive(r: ClientType, real_server_details):
     r.sadd("foo", "member1")
+    is_dragonfly = real_server_details.server_type == "dragonfly"
     for numkeys in (0, -1):
-        with pytest.raises(Exception, match="numkeys should be greater than 0") as ctx:
+        # Dragonfly reads numkeys as unsigned, so -1 fails to decode before the key check.
+        if is_dragonfly:
+            expected = "at least 1 input key is needed" if numkeys == 0 else "value is not an integer or out of range"
+        else:
+            expected = "numkeys should be greater than 0"
+        with pytest.raises(Exception, match=expected) as ctx:
             testtools.raw_command(r, "sintercard", numkeys, "foo")
         assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
-def test_sintercard_numkeys_greater_than_keys(r: ClientType):
+def test_sintercard_numkeys_greater_than_keys(r: ClientType, real_server_details):
     r.sadd("foo", "member1")
-    with pytest.raises(Exception, match="Number of keys can't be greater than number of args") as ctx:
+    # Dragonfly reports a numkeys that overruns the key list as a plain syntax error.
+    expected = (
+        "syntax error"
+        if real_server_details.server_type == "dragonfly"
+        else "Number of keys can't be greater than number of args"
+    )
+    with pytest.raises(Exception, match=expected) as ctx:
         testtools.raw_command(r, "sintercard", 9, "foo")
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 
 
-def test_spop_negative_count(r: ClientType):
+def test_spop_negative_count(r: ClientType, real_server_details):
     r.sadd("foo", "member1")
-    with pytest.raises(Exception, match="value is out of range, must be positive") as ctx:
+    # Dragonfly fails while decoding the count, so it gives the generic integer error.
+    expected = (
+        "value is not an integer or out of range"
+        if real_server_details.server_type == "dragonfly"
+        else "value is out of range, must be positive"
+    )
+    with pytest.raises(Exception, match=expected) as ctx:
         r.spop("foo", -1)
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
     assert r.scard("foo") == 1

--- a/test/test_mixins/test_sortedset_commands.py
+++ b/test/test_mixins/test_sortedset_commands.py
@@ -1245,13 +1245,19 @@ def test_zintercard(r: ClientType):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
-def test_zintercard_negative_limit(r: ClientType):
+def test_zintercard_negative_limit(r: ClientType, real_server_details):
     r.zadd("a", {"a1": 1, "a2": 2})
     r.zadd("b", {"a1": 2, "a2": 2})
     with pytest.raises(Exception) as ctx:
         r.zintercard(2, ["a", "b"], limit=-1)
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
-    assert "LIMIT can't be negative" in str(ctx.value)
+    # Dragonfly words the ZINTERCARD limit check differently from the SINTERCARD one.
+    expected = (
+        "limit value is not a positive integer"
+        if real_server_details.server_type == "dragonfly"
+        else "LIMIT can't be negative"
+    )
+    assert expected in str(ctx.value)
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
@@ -1321,8 +1327,19 @@ def test_zrangebyscore_negative_start_after_sort(r: ClientType):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
-def test_zmpop_count_not_positive(r: ClientType):
+def test_zmpop_count_not_positive(r: ClientType, real_server_details):
     r.zadd("foo", {"a": 1, "b": 2})
+    if real_server_details.server_type == "dragonfly":
+        # Dragonfly accepts both: COUNT 0 pops nothing, and a negative count is read as
+        # unsigned and so pops the whole sorted set.
+        assert testtools.raw_command(r, "zmpop", 1, "foo", "MIN", "COUNT", 0) == [b"foo", []]
+        assert r.zcard("foo") == 2
+        assert testtools.raw_command(r, "zmpop", 1, "foo", "MIN", "COUNT", -1) == [
+            b"foo",
+            resp_conversion(r, [[b"a", 1.0], [b"b", 2.0]], [[b"a", b"1"], [b"b", b"2"]]),
+        ]
+        assert r.zcard("foo") == 0
+        return
     for count in (0, -1):
         with pytest.raises(Exception, match="count should be greater than 0") as ctx:
             testtools.raw_command(r, "zmpop", 1, "foo", "MIN", "COUNT", count)
@@ -1335,10 +1352,16 @@ def test_zmpop_count_not_positive(r: ClientType):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
-def test_zmpop_numkeys_not_positive(r: ClientType):
+def test_zmpop_numkeys_not_positive(r: ClientType, real_server_details):
     r.zadd("foo", {"a": 1})
+    is_dragonfly = real_server_details.server_type == "dragonfly"
     for numkeys in (0, -1):
-        with pytest.raises(Exception, match="numkeys should be greater than 0") as ctx:
+        # Dragonfly reads numkeys as unsigned, so -1 fails to decode before the key check.
+        if is_dragonfly:
+            expected = "at least 1 input key is needed" if numkeys == 0 else "value is not an integer or out of range"
+        else:
+            expected = "numkeys should be greater than 0"
+        with pytest.raises(Exception, match=expected) as ctx:
             testtools.raw_command(r, "zmpop", numkeys, "foo", "MIN")
         assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 

--- a/test/test_mixins/test_string_commands.py
+++ b/test/test_mixins/test_string_commands.py
@@ -566,6 +566,7 @@ def test_getex_no_option_keeps_ttl(r: ClientType):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
+@pytest.mark.unsupported_server_types("dragonfly")  # dragonfly has no LCS, see test_dragonfly
 def test_lcs(r: ClientType):
     r.mset({"key1": "ohmytext", "key2": "mynewtext"})
     assert r.lcs("key1", "key2") == b"mytext"

--- a/test/test_tcp_server/test_connectivity.py
+++ b/test/test_tcp_server/test_connectivity.py
@@ -8,6 +8,7 @@ import pytest
 import redis
 
 from fakeredis._tcp_server import TcpFakeServer
+from test.conftest import ServerDetails
 
 pytestmark = []
 pytestmark.extend(
@@ -31,10 +32,20 @@ def test_tcp_server_connection_reset_error(tcp_server_address: tuple[str, int]):
         assert r.rpop("test") == b"foo"
 
 
-def test_bulk_string_length(real_server_address: tuple[str, int], tcp_server_address: tuple[str, int]):
+def test_bulk_string_length(
+    real_server_address: tuple[str, int],
+    tcp_server_address: tuple[str, int],
+    real_server_details: ServerDetails,
+):
     """Test that malformed bulk string input is handled correctly."""
     import socket
     from contextlib import closing
+
+    # Dragonfly reports unknown commands in its own wording, without echoing the arguments back.
+    if real_server_details.server_type == "dragonfly":
+        expected = "-ERR unknown command `$`\r\n"
+    else:
+        expected = "-ERR unknown command '$', with args beginning with: '1' \r\n"
 
     connections = [real_server_address, tcp_server_address]
     for conn in connections:
@@ -43,9 +54,7 @@ def test_bulk_string_length(real_server_address: tuple[str, int], tcp_server_add
             s.connect((host, port))
             s.sendall(b"$ 1\ntest")
             data = s.recv(1024).decode()
-            assert data == "-ERR unknown command '$', with args beginning with: '1' \r\n", (
-                f"Failed for server at {host}:{port}"
-            )
+            assert data == expected, f"Failed for server at {host}:{port}"
 
 
 def test_tcp_server_started_protocol_3(tcp_server_address: tuple[str, int]):


### PR DESCRIPTION
Dragonfly reports a fair number of argument errors differently from Redis, and
in a few cases accepts what Redis rejects. The pattern behind most of it is that
Dragonfly decodes `numkeys` and `COUNT` as *unsigned*, so a negative value never
reaches the semantic check and comes back as the generic "value is not an
integer or out of range".

* Unknown commands are reported as ``unknown command `SETEX` `` -- backticked,
  upper-cased, and without echoing the arguments. `_extract_line` and
  `_name_to_func` build the error through a new `_unknown_command` helper.
* SCAN COUNT: a zero is accepted and falls back to the default batch size; a
  negative one fails to decode.
* LMPOP/BLMPOP/ZMPOP/BZMPOP: COUNT 0 is accepted and names the first existing
  key while popping nothing. A negative COUNT is rejected by LMPOP but read as
  unsigned by ZMPOP, which then pops the whole sorted set.
* SINTERCARD/ZINTERCARD/ZUNION/ZINTER/ZDIFF: their own wording for the numkeys
  and LIMIT complaints, and a plain syntax error when numkeys overruns the key
  list.
* LPOS RANK/COUNT/MAXLEN and SPOP's count report the generic integer error
  rather than naming the offending option.
* SMOVE checks its destination's type up front, so moving out of a missing set
  into a string fails where Redis answers 0.
* LCS does not exist on Dragonfly at all.

The Redis-side tests keep their existing assertions; the Dragonfly side is
covered by the new `test/test_dragonfly/test_dragonfly_divergences.py` and by
`real_server_details` branches where the two answers sit in one test.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!--STACK-->
### This PR is part of a stack

`#373` split into twelve reviewable pieces. Each branches off the one above it, so they
merge in order; the diff shown here is only this step's own changes.

**#553 and #554 are merged.** #554 went into `df/01-prep` first, so master's squash commit
`b22d569e` carries both; the rest of the stack has been rebased onto master accordingly.

| PR | Branch | What it covers |
|---|--------|----------------|
| ~~#553~~ ✅ | `df/01-prep` | Server-agnostic fixes: SMOVE, BITCOUNT, GEO ordering, shared zset reply shaping |
| ~~#554~~ ✅ | `df/02-harness` | Build `FakeServer` with the Redis version Dragonfly reports; TCP server + CI plumbing |
| #555 | `df/03-errors` | Error wording and argument validation |
| #556 | `df/04-limits` | Expiry horizon, hash-field TTL cap, 256MB value cap |
| #557 | `df/05-reply-shapes` | Doubles, timed-out blocking pops, sorted-set reply shapes |
| #558 | `df/06-streams` | XREAD/XREADGROUP/XINFO/XPENDING replies |
| #559 | `df/07-pubsub` | Shard and plain channels in one namespace |
| #560 | `df/08-sort-copy-geo` | SORT patterns, COPY without DB, GEO ordering |
| #561 | `df/09-transactions` | WATCH invalidation and MULTI queueing |
| #562 | `df/10-scripting` | Lua 5.4 semantics and script error wording |
| #563 | `df/11-json` | Dragonfly's own JSON implementation |
| #564 | `df/12-hypothesis-docs` | Hypothesis guards + `docs/dragonfly-support.md` |

Verified against a real Dragonfly (`df-v1.40.1`) and a real Redis (`8.4.0`, all modules loaded): every
branch in the stack has an identical failure set to `master`, and the tip of the stack has two
*fewer* failures than `master` (PR #559 repairs a pre-existing pub/sub subscription leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
