### PR TITLE
feat(dragonfly): match the reply shapes it sends for doubles, empty pops and zsets

### DIFF
--- a/fakeredis/_basefakesocket.py
+++ b/fakeredis/_basefakesocket.py
@@ -32,16 +32,20 @@ from ._typing import ResponseErrorType, ServerType, VersionType
 LOGGER = logging.getLogger("fakeredis")
 
 
-def _convert_to_resp2(val: Any) -> Any:
+def _convert_to_resp2(val: Any, server_type: ServerType = "redis", keep_doubles: bool = False) -> Any:
     if isinstance(val, str):
         return val.encode()
     if isinstance(val, float):
+        if keep_doubles:
+            return val
+        if server_type == "dragonfly":
+            return Float.encode_shortest(val)
         return Float.encode(val, humanfriendly=False)
     if isinstance(val, dict):
         result = list(itertools.chain(*val.items()))
-        return [_convert_to_resp2(item) for item in result]
+        return [_convert_to_resp2(item, server_type, keep_doubles) for item in result]
     if isinstance(val, (list, tuple)):
-        return [_convert_to_resp2(item) for item in val]
+        return [_convert_to_resp2(item, server_type, keep_doubles) for item in val]
     return val
 
 
@@ -347,7 +351,7 @@ class BaseFakeSocket:
                 args, command_items = ret
                 result = func(*args)  # type: ignore
                 if self._client_info.protocol_version == 2 and msgs.FLAG_SKIP_CONVERT_TO_RESP2 not in sig.flags:
-                    result = _convert_to_resp2(result)
+                    result = _convert_to_resp2(result, self.server_type)
                 if msgs.FLAG_SKIP_CONVERT_TO_RESP2 not in sig.flags and not valid_response_type(
                     result, self._client_info.protocol_version
                 ):
@@ -467,7 +471,9 @@ class BaseFakeSocket:
         else:
             return result
 
-    def _blocking(self, timeout: float | None, func: Callable[[bool], Any]) -> Any:
+    def _blocking(
+        self, timeout: float | None, func: Callable[[bool], Any], shape: Callable[[Any], Any] | None = None
+    ) -> Any:
         """Run a function until it succeeds or timeout is reached.
 
         The timeout is in seconds, and 0 means infinite. The function
@@ -476,26 +482,32 @@ class BaseFakeSocket:
         each time the condition variable is notified, until the timeout is
         reached.
 
+        `shape` turns the outcome into the reply the command sends, the timed-out None
+        included. It belongs here rather than around the call because the async socket
+        answers a command that blocks outside the command's own control flow, so anything
+        the command does with the return value would be skipped there.
+
         Returns the function return value, or None if the timeout has passed.
         """
         ret = func(True)  # Call with first_pass=True
         if ret is not None or self._in_transaction:
-            return ret
+            return ret if shape is None else shape(ret)
+        empty = None if shape is None else shape(None)
         deadline = time.time() + timeout if timeout else None
         self._blocked = True
         try:
             while True:
                 timeout = (deadline - time.time()) if deadline is not None else None
                 if timeout is not None and timeout <= 0:
-                    return None
+                    return empty
                 if self._db.condition.wait(timeout=timeout) is False:
-                    return None  # Timeout expired
+                    return empty  # Timeout expired
                 if self._unblock_reason is not None:
                     self._take_unblock_reason()
-                    return None  # Unblocked with TIMEOUT: same empty result as a timeout
+                    return empty  # Unblocked with TIMEOUT: same empty result as a timeout
                 ret = func(False)  # Second pass => first_pass=False
                 if ret is not None:
-                    return ret
+                    return ret if shape is None else shape(ret)
         finally:
             self._blocked = False
             self._unblock_reason = None

--- a/fakeredis/_commands.py
+++ b/fakeredis/_commands.py
@@ -203,6 +203,21 @@ class Float(RedisType):
             raise SimpleError(decode_error or cls.DECODE_ERROR)
 
     @classmethod
+    def encode_shortest(cls, value: float) -> bytes:
+        """Render a double the way Dragonfly does, as the shortest string that round-trips.
+
+        Redis pads doubles out to 17 significant digits, so a score of 3.2 comes back as
+        ``3.2000000000000002``; Dragonfly prints ``3.2``, and drops the fractional part
+        altogether for whole numbers.
+        """
+        if math.isinf(value):
+            return str(value).encode()
+        out = repr(value)
+        if out.endswith(".0"):
+            out = out[:-2]
+        return out.encode()
+
+    @classmethod
     def encode(cls, value: float, humanfriendly: bool) -> bytes:
         if math.isinf(value):
             return str(value).encode()

--- a/fakeredis/aioredis.py
+++ b/fakeredis/aioredis.py
@@ -56,8 +56,10 @@ class AsyncFakeSocket(_fakesocket.FakeSocket):
         func: Callable[[bool], Any],
         event: asyncio.Event,
         callback: Callable[[], None],
+        shape: Callable[[Any], Any] | None = None,
     ) -> None:
-        result = None
+        # The reply for an empty outcome -- a timeout, or an unblock with TIMEOUT.
+        result = None if shape is None else self._decode_result(shape(None))
         try:
             async with async_timeout(timeout if timeout else None):
                 while True:
@@ -74,7 +76,7 @@ class AsyncFakeSocket(_fakesocket.FakeSocket):
                             break
                         ret = func(False)
                         if ret is not None:
-                            result = self._decode_result(ret)
+                            result = self._decode_result(ret if shape is None else shape(ret))
                             break
         except asyncio.TimeoutError:
             pass
@@ -90,11 +92,12 @@ class AsyncFakeSocket(_fakesocket.FakeSocket):
         self,
         timeout: float | None,
         func: Callable[[bool], None],
+        shape: Callable[[Any], Any] | None = None,
     ) -> Any:
         loop = asyncio.get_event_loop()
         ret = func(True)
         if ret is not None or self._in_transaction:
-            return ret
+            return ret if shape is None else shape(ret)
         event = asyncio.Event()
 
         def callback() -> None:
@@ -103,7 +106,9 @@ class AsyncFakeSocket(_fakesocket.FakeSocket):
         self._db.add_change_callback(callback)
         self._blocked = True
         self.pause()
-        loop.create_task(self._async_blocking(timeout, func, event, callback))
+        # `shape` travels with the task: the reply is put on the queue from there, past
+        # the point where the command that blocked could still touch it.
+        loop.create_task(self._async_blocking(timeout, func, event, callback, shape))
         return _helpers.NoResponse()
 
 

--- a/fakeredis/commands_mixins/_mixin_base.py
+++ b/fakeredis/commands_mixins/_mixin_base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
 from fakeredis._typing import ServerType, VersionType
 
@@ -24,3 +24,20 @@ class CommandsMixinBase:
     @property
     def server_type(self) -> ServerType:
         raise NotImplementedError
+
+    def _blocking(
+        self, timeout: float | None, func: Callable[[bool], Any], shape: Callable[[Any], Any] | None = None
+    ) -> Any:
+        """Implemented by the socket, sync and async alike; see `FakeSocket._blocking`."""
+        raise NotImplementedError
+
+    def _empty_blocking_reply(self, result: Any) -> Any:
+        """Shape a timed-out array-returning blocking pop (BLPOP/BRPOP/BZPOPMIN/BZPOPMAX).
+
+        Redis sends a null array, which RESP3 renders as nil. Dragonfly sends an empty
+        array instead, so under RESP3 the client sees `[]` rather than `None`. Under RESP2
+        both encode to `*-1` and the client sees `None` either way.
+        """
+        if result is None and self.server_type == "dragonfly" and self._client_info.protocol_version == 3:
+            return []
+        return result

--- a/fakeredis/commands_mixins/hash_mixin.py
+++ b/fakeredis/commands_mixins/hash_mixin.py
@@ -73,7 +73,7 @@ class HashCommandsMixin(CommandsMixinBase):
         return c
 
     @command((Key(Hash), bytes, bytes))
-    def hincrbyfloat(self, key: CommandItem, field: bytes, amount: bytes) -> bytes:
+    def hincrbyfloat(self, key: CommandItem, field: bytes, amount: bytes) -> bytes | float:
         c = Float.decode(key.value.get(field, b"0")) + Float.decode(amount)
         if not math.isfinite(c):
             raise SimpleError(msgs.NONFINITE_MSG)
@@ -81,7 +81,8 @@ class HashCommandsMixin(CommandsMixinBase):
         key.value.update({field: encoded}, clear_expiration=False)
         key.updated()
         self.add_subkey_event(b"hincrbyfloat", key.key, (field,))
-        return encoded
+        # Redis replies with a bulk string, Dragonfly with a double.
+        return c if self.server_type == "dragonfly" else encoded
 
     @command((Key(Hash),))
     def hkeys(self, key: CommandItem) -> list[bytes]:

--- a/fakeredis/commands_mixins/list_mixin.py
+++ b/fakeredis/commands_mixins/list_mixin.py
@@ -44,8 +44,6 @@ def _list_pop(get_slice: Callable[[int], slice], key: CommandItem, *args: bytes)
 
 
 class ListCommandsMixin(CommandsMixinBase):
-    _blocking: Callable[[float | int | None, Callable[[bool], Any]], Any]
-
     def _bpop_pass(self, keys: list[bytes], op: Callable[[list[bytes]], bytes], first_pass: bool) -> list[bytes] | None:
         for key in keys:
             item = CommandItem(key, self._db, item=self._db.get(key), default=[])
@@ -64,7 +62,7 @@ class ListCommandsMixin(CommandsMixinBase):
     def _bpop(self, args: Any, op: Callable[[list[bytes]], bytes]) -> Any:
         keys = args[:-1]
         timeout = Timeout.decode(args[-1])
-        return self._blocking(timeout, functools.partial(self._bpop_pass, keys, op))
+        return self._blocking(timeout, functools.partial(self._bpop_pass, keys, op), self._empty_blocking_reply)
 
     @command((bytes, bytes), (bytes,), flags=msgs.FLAG_NO_SCRIPT)
     def blpop(self, *args: bytes) -> Any:

--- a/fakeredis/commands_mixins/sortedset_mixin.py
+++ b/fakeredis/commands_mixins/sortedset_mixin.py
@@ -82,7 +82,6 @@ class ScoreTest(RedisType):
 
 
 class SortedSetCommandsMixin(CommandsMixinBase):
-    _blocking: Callable[[float | int | None, Callable[[bool], Any]], Any]
     _scan: Callable[..., Any]
     _encodefloat: Callable[[float, bool], bytes]
 
@@ -117,7 +116,9 @@ class SortedSetCommandsMixin(CommandsMixinBase):
     def _zpop_flatten(self, count: int | None) -> bool:
         # RESP2 always returns a flat list. RESP3 returns a flat member/score pair
         # only when no count was given; with an explicit count it returns an array
-        # of pairs.
+        # of pairs. Dragonfly answers RESP3 with an array of pairs either way.
+        if self.server_type == "dragonfly":
+            return self._client_info.protocol_version == 2
         return self._client_info.protocol_version == 2 or count is None
 
     @command((Key(ZSet),), (Int,))
@@ -132,13 +133,15 @@ class SortedSetCommandsMixin(CommandsMixinBase):
     def bzpopmin(self, *args: bytes) -> list[list[bytes]] | None:
         keys = args[:-1]
         timeout = Timeout.decode(args[-1])
-        return self._blocking(timeout, functools.partial(self._bzpop, keys, False))  # type:ignore
+        res = self._blocking(timeout, functools.partial(self._bzpop, keys, False), self._empty_blocking_reply)  # type:ignore
+        return res  # type:ignore
 
     @command((bytes, bytes), (bytes,), flags=msgs.FLAG_NO_SCRIPT)
     def bzpopmax(self, *args: bytes) -> list[list[bytes]] | None:
         keys = args[:-1]
         timeout = Timeout.decode(args[-1])
-        return self._blocking(timeout, functools.partial(self._bzpop, keys, True))  # type:ignore
+        res = self._blocking(timeout, functools.partial(self._bzpop, keys, True), self._empty_blocking_reply)  # type:ignore
+        return res  # type:ignore
 
     @staticmethod
     def _limit_items(items: list[_T], offset: int, count: int) -> list[_T]:
@@ -457,11 +460,14 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         else:
             raise SimpleError(msgs.WRONGTYPE_MSG)
 
-    def _zset_scores_reply(self, zset: ZSet, withscores: bool) -> list[Any]:
-        """Shape the reply of a ZDIFF/ZUNION/ZINTER, which RESP3 pairs up member and score."""
+    def _zset_scores_reply(self, zset: ZSet, withscores: bool, flat_on_dragonfly: bool = False) -> list[Any]:
+        """Shape the reply of a ZDIFF/ZUNION/ZINTER, which RESP3 pairs up member and score.
+
+        Dragonfly keeps the flat RESP2 shape for ZUNION and ZINTER, but not for ZDIFF.
+        """
         if not withscores:
             return list(zset)
-        if self._client_info.protocol_version == 2:
+        if self._client_info.protocol_version == 2 or (flat_on_dragonfly and self.server_type == "dragonfly"):
             return [item for member in zset for item in (member, zset[member])]
         return [[member, zset[member]] for member in zset]
 
@@ -493,9 +499,14 @@ class SortedSetCommandsMixin(CommandsMixinBase):
             else:
                 raise SimpleError(msgs.SYNTAX_ERROR_MSG)
 
+        # Redis reads a plain set as a sorted set scoring every member 1. Dragonfly does
+        # that too, except in ZDIFF/ZDIFFSTORE, which only accept sorted sets.
+        zsets_only = self.server_type == "dragonfly" and func in {"ZDIFF", "ZDIFFSTORE"}
         sets = []
         for i in range(numkeys):
             item = CommandItem(args[i], self._db, item=self._db.get(args[i]), default=ZSet())
+            if zsets_only and isinstance(item.value, ExpiringMembersSet):
+                raise SimpleError(msgs.WRONGTYPE_MSG)
             sets.append(self._get_zset(item.value))
 
         out_members = set(sets[0])
@@ -569,7 +580,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         sets = args[:-1] if withscores else args
         zset_res = self._zunioninterdiff("ZUNION", None, numkeys, *sets)
         assert isinstance(zset_res, ZSet)
-        return self._zset_scores_reply(zset_res, withscores)
+        return self._zset_scores_reply(zset_res, withscores, flat_on_dragonfly=True)
 
     @command((Int, bytes), (bytes,))
     def zinter(self, numkeys: int, *args: bytes) -> list[Any]:
@@ -577,7 +588,7 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         sets = args[:-1] if withscores else args
         zset_res = self._zunioninterdiff("ZINTER", None, numkeys, *sets)
         assert isinstance(zset_res, ZSet)
-        return self._zset_scores_reply(zset_res, withscores)
+        return self._zset_scores_reply(zset_res, withscores, flat_on_dragonfly=True)
 
     @command(name="ZINTERCARD", fixed=(Int, bytes), repeat=(bytes,))
     def zintercard(self, numkeys: int, *args: bytes) -> int:

--- a/fakeredis/commands_mixins/streams_mixin.py
+++ b/fakeredis/commands_mixins/streams_mixin.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-from typing import Any, Callable
+from typing import Any
 
 import fakeredis._msgs as msgs
 from fakeredis._command_args_parsing import extract_args
@@ -12,8 +12,6 @@ from fakeredis.model import StreamGroup, StreamRangeTest, XStream
 
 
 class StreamsCommandsMixin(CommandsMixinBase):
-    _blocking: Callable[[float | int | None, Callable[[bool], Any]], Any]
-
     @command(name="XADD", fixed=(Key(),), repeat=(bytes,))
     def xadd(self, key: CommandItem, *args: bytes) -> bytes | None:
         (nomkstream, limit, maxlen, minid, idmpauto, idmp), left_args = extract_args(

--- a/fakeredis/commands_mixins/string_mixin.py
+++ b/fakeredis/commands_mixins/string_mixin.py
@@ -224,13 +224,14 @@ class StringCommandsMixin(CommandsMixinBase, ABC):
         return [result, amount]
 
     @command(fixed=(Key(bytes), Float))
-    def incrbyfloat(self, key: CommandItem, amount: float) -> bytes:
+    def incrbyfloat(self, key: CommandItem, amount: float) -> bytes | float:
         c = Float.decode(key.get(b"0")) + amount
         if not math.isfinite(amount):
             raise SimpleError(msgs.NONFINITE_MSG)
         encoded = self._encodefloat(c, True)
         key.update(encoded)
-        return encoded
+        # Redis replies with a bulk string, Dragonfly with a double.
+        return c if self.server_type == "dragonfly" else encoded
 
     @command(fixed=(Key(),), repeat=(Key(),))
     def mget(self, *keys: CommandItem) -> list[bytes | None]:

--- a/test/test_async/test_blocking.py
+++ b/test/test_async/test_blocking.py
@@ -6,7 +6,8 @@ import redis
 import valkey
 
 from fakeredis._typing import AsyncClientType
-from test.testtools import resp_conversion
+from test.conftest import ServerDetails
+from test.testtools import empty_blocking_reply, resp_conversion
 
 pytestmark = []
 pytestmark.extend(
@@ -31,10 +32,10 @@ async def test_blocking_ready(async_redis, conn):
 
 
 @pytest.mark.slow
-async def test_blocking_timeout(conn):
+async def test_blocking_timeout(conn, real_server_details: ServerDetails):
     """Blocking command that times out without completing."""
     result = await conn.blpop("missing", timeout=1)
-    assert result is None
+    assert result == empty_blocking_reply(conn, real_server_details.server_type)
 
 
 @pytest.mark.slow

--- a/test/test_dragonfly/test_dragonfly_divergences.py
+++ b/test/test_dragonfly/test_dragonfly_divergences.py
@@ -12,7 +12,7 @@ import time
 import pytest
 
 from fakeredis._typing import ClientType
-from test.testtools import raw_command
+from test.testtools import raw_command, resp_conversion
 
 pytestmark = []
 pytestmark.extend(
@@ -83,6 +83,43 @@ def test_at_least_one_key_is_needed_for_numkeys_commands(r: ClientType):
     # Dragonfly reads numkeys as unsigned, so a negative one never decodes.
     for args in (("sintercard", -1, "s"), ("zintercard", -1, "z")):
         _raises(r, "value is not an integer or out of range", *args)
+
+
+def test_zpopmin_returns_an_array_of_pairs_under_resp3(r: ClientType):
+    # Redis answers a countless ZPOPMIN/ZPOPMAX with a flat member/score pair under RESP3;
+    # dragonfly wraps it in an array, exactly as it does for the counted form.
+    r.zadd("z", {"a": 1.0, "b": 2.0})
+    expected = resp_conversion(r, [[b"a", 1.0]], [b"a", b"1"])
+    assert raw_command(r, "zpopmin", "z") == expected
+    assert raw_command(r, "zpopmax", "z") == resp_conversion(r, [[b"b", 2.0]], [b"b", b"2"])
+
+
+def test_zpopmin_on_a_missing_key_is_still_an_empty_array(r: ClientType):
+    assert raw_command(r, "zpopmin", "nosuchkey") == []
+
+
+def test_zunion_and_zinter_keep_the_flat_withscores_shape(r: ClientType):
+    # Under RESP3 redis pairs each member with its score; dragonfly keeps the RESP2 shape
+    # for these two, though not for ZDIFF.
+    r.zadd("a", {"m": 1.0})
+    r.zadd("b", {"m": 2.0})
+    for command in ("zunion", "zinter"):
+        assert raw_command(r, command, 2, "a", "b", "withscores") == resp_conversion(r, [b"m", 3.0], [b"m", b"3"])
+    assert raw_command(r, "zdiff", 2, "a", "nosuchkey", "withscores") == resp_conversion(r, [[b"m", 1.0]], [b"m", b"1"])
+
+
+def test_zdiff_only_accepts_sorted_sets(r: ClientType):
+    # Redis reads a plain set as a sorted set scoring every member 1; so does dragonfly,
+    # except here.
+    r.sadd("s", "m")
+    r.zadd("z", {"m": 1.0})
+    _raises(r, "WRONGTYPE", "zdiff", 2, "s", "z")
+    _raises(r, "WRONGTYPE", "zdiff", 2, "z", "s")
+    _raises(r, "WRONGTYPE", "zdiffstore", "dst", 2, "z", "s")
+    # The other set operations do take it.
+    assert raw_command(r, "zinterstore", "dst", 2, "s", "z") == 1
+    assert raw_command(r, "zunionstore", "dst", 2, "s", "z") == 1
+    assert raw_command(r, "zintercard", 2, "s", "z") == 1
 
 
 def test_smove_checks_the_destination_type_even_when_the_source_is_missing(r: ClientType):

--- a/test/test_mixins/test_list_commands.py
+++ b/test/test_mixins/test_list_commands.py
@@ -534,13 +534,13 @@ def test_blpop_wrong_type(r: ClientType):
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 
 
-def test_blpop_transaction(r: ClientType):
+def test_blpop_transaction(r: ClientType, real_server_details):
     p = r.pipeline()
     p.multi()
     p.blpop("missing", timeout=1000)
     result = p.execute()
     # Blocking commands behave like non-blocking versions in transactions
-    assert result == [None]
+    assert result == [testtools.empty_blocking_reply(r, real_server_details.server_type)]
 
 
 def test_brpop_test_multiple_lists(r: ClientType):
@@ -595,10 +595,12 @@ def test_brpoplpush_wrong_type(r: ClientType):
 
 
 @pytest.mark.slow
-def test_blocking_operations_when_empty(r: ClientType):
-    assert r.blpop(["foo"], timeout=1) is None
-    assert r.blpop(["bar", "foo"], timeout=1) is None
-    assert r.brpop("foo", timeout=1) is None
+def test_blocking_operations_when_empty(r: ClientType, real_server_details):
+    empty = testtools.empty_blocking_reply(r, real_server_details.server_type)
+    assert r.blpop(["foo"], timeout=1) == empty
+    assert r.blpop(["bar", "foo"], timeout=1) == empty
+    assert r.brpop("foo", timeout=1) == empty
+    # BRPOPLPUSH replies with a bulk string, which is nil on every server.
     assert r.brpoplpush("foo", "bar", timeout=1) is None
 
 

--- a/test/testtools.py
+++ b/test/testtools.py
@@ -133,3 +133,19 @@ def far_future_expiry(server_type: str) -> int:
     if server_type == "dragonfly":
         return int(time.time()) + 10_000_000
     return 33177117420
+
+
+def null_array_reply(r: redis.Redis, server_type: str) -> Any:
+    """What a reply redis sends as a null array reads back as on the server under test.
+
+    Dragonfly keeps sending the RESP2 null array (`*-1`) under RESP3, where redis sends
+    nil, so a RESP3 client reads it back as `[]`. Under RESP2 both read back as None.
+    """
+    if server_type == "dragonfly" and get_protocol_version(r) == 3:
+        return []
+    return None
+
+
+def empty_blocking_reply(r: redis.Redis, server_type: str) -> Any:
+    """What a timed-out BLPOP/BRPOP/BZPOPMIN looks like on the server under test."""
+    return null_array_reply(r, server_type)


### PR DESCRIPTION
Four reply-shape divergences, all of which a RESP3 client sees and a RESP2 one
mostly does not:

* **Doubles.** INCRBYFLOAT and HINCRBYFLOAT reply with a double where Redis
  sends a bulk string. Where a double does have to be rendered as text,
  Dragonfly prints the shortest string that round-trips -- `3.2`, and `3` for a
  whole number -- rather than padding to Redis' 17 significant digits, which
  `Float.encode_shortest` now does.
* **Timed-out blocking pops.** BLPOP/BRPOP/BZPOPMIN/BZPOPMAX answer with an
  empty array rather than a null array, so a RESP3 client reads `[]` where it
  reads `None` against Redis. Shaping this needed a `shape` callback on
  `_blocking`: the async socket answers a blocked command from its own task,
  past the point where the command's own control flow could touch the result,
  so the shaping has to travel with the task rather than wrap the call.
* **ZPOPMIN/ZPOPMAX** answer RESP3 with an array of pairs whether or not a
  COUNT was given, where Redis flattens the no-COUNT case.
* **ZUNION/ZINTER** keep the flat RESP2 WITHSCORES shape under RESP3 -- but
  ZDIFF does not, so the three cannot share one answer.

ZDIFF/ZDIFFSTORE also refuse a plain set as input, where every other
sorted-set-combining command reads one as a sorted set scoring each member 1.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!--STACK-->
### This PR is part of a stack

`#373` split into twelve reviewable pieces. Each branches off the one above it, so they
merge in order; the diff shown here is only this step's own changes.

**#553 and #554 are merged.** #554 went into `df/01-prep` first, so master's squash commit
`b22d569e` carries both; the rest of the stack has been rebased onto master accordingly.

| PR | Branch | What it covers |
|---|--------|----------------|
| ~~#553~~ ✅ | `df/01-prep` | Server-agnostic fixes: SMOVE, BITCOUNT, GEO ordering, shared zset reply shaping |
| ~~#554~~ ✅ | `df/02-harness` | Build `FakeServer` with the Redis version Dragonfly reports; TCP server + CI plumbing |
| #555 | `df/03-errors` | Error wording and argument validation |
| #556 | `df/04-limits` | Expiry horizon, hash-field TTL cap, 256MB value cap |
| #557 | `df/05-reply-shapes` | Doubles, timed-out blocking pops, sorted-set reply shapes |
| #558 | `df/06-streams` | XREAD/XREADGROUP/XINFO/XPENDING replies |
| #559 | `df/07-pubsub` | Shard and plain channels in one namespace |
| #560 | `df/08-sort-copy-geo` | SORT patterns, COPY without DB, GEO ordering |
| #561 | `df/09-transactions` | WATCH invalidation and MULTI queueing |
| #562 | `df/10-scripting` | Lua 5.4 semantics and script error wording |
| #563 | `df/11-json` | Dragonfly's own JSON implementation |
| #564 | `df/12-hypothesis-docs` | Hypothesis guards + `docs/dragonfly-support.md` |

Verified against a real Dragonfly (`df-v1.40.1`) and a real Redis (`8.4.0`, all modules loaded): every
branch in the stack has an identical failure set to `master`, and the tip of the stack has two
*fewer* failures than `master` (PR #559 repairs a pre-existing pub/sub subscription leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
