### PR TITLE
feat(dragonfly): match the stream replies it sends

### DIFF
--- a/fakeredis/commands_mixins/streams_mixin.py
+++ b/fakeredis/commands_mixins/streams_mixin.py
@@ -83,12 +83,14 @@ class StreamsCommandsMixin(CommandsMixinBase):
             start_id = self._parse_start_id(item, left_args[i + num_streams])
             stream_start_id_list.append((left_args[i], start_id))
         if timeout is None:
-            return self._xread(stream_start_id_list, count, blocking=False, first_pass=False)
-        else:
-            return self._blocking(  # type: ignore
-                timeout / 1000.0,
-                functools.partial(self._xread, stream_start_id_list, count, True),
+            return self._empty_stream_read_reply(
+                self._xread(stream_start_id_list, count, blocking=False, first_pass=False)
             )
+        return self._blocking(  # type: ignore[no-any-return]
+            timeout / 1000.0,
+            functools.partial(self._xread, stream_start_id_list, count, True),
+            self._empty_stream_read_reply,
+        )
 
     @command(name="XREADGROUP", fixed=(bytes, bytes, bytes), repeat=(bytes,))
     def xreadgroup(
@@ -119,15 +121,14 @@ class StreamsCommandsMixin(CommandsMixinBase):
                 )
             group_params.append((group, left_args[i], left_args[i + num_streams]))
         if timeout is None:
-            res = self._xreadgroup(consumer_name, group_params, count, noack, min_idle_time, False)
-        else:
-            res = self._blocking(
-                timeout / 1000.0,
-                functools.partial(self._xreadgroup, consumer_name, group_params, count, noack, min_idle_time),
+            return self._xreadgroup_reply(
+                self._xreadgroup(consumer_name, group_params, count, noack, min_idle_time, False)
             )
-        if self._client_info.protocol_version == 2:
-            return [[k, v] for k, v in res.items()] if res else None
-        return res
+        return self._blocking(  # type: ignore[no-any-return]
+            timeout / 1000.0,
+            functools.partial(self._xreadgroup, consumer_name, group_params, count, noack, min_idle_time),
+            self._xreadgroup_reply,
+        )
 
     @command(name="XDEL", fixed=(Key(XStream),), repeat=(bytes,))
     def xdel(self, key: CommandItem, *args: bytes) -> int:
@@ -154,7 +155,12 @@ class StreamsCommandsMixin(CommandsMixinBase):
         flags=msgs.FLAG_DO_NOT_CREATE,
     )
     def xpending(self, key: CommandItem, group_name: bytes, *args: bytes) -> int | list[Any]:
+        # Dragonfly looks the key up before the group, so a missing stream is "no such key"
+        # and a missing group names only the group it could not find.
+        is_dragonfly = self.server_type == "dragonfly"
         if key.value is None:
+            if is_dragonfly:
+                raise SimpleError(msgs.NO_KEY_MSG)
             raise SimpleError(msgs.XNACK_NOGROUP_MSG.format(key.key.decode(), group_name.decode()))
         idle, start, end, count, consumer = None, None, None, None, None
 
@@ -173,6 +179,8 @@ class StreamsCommandsMixin(CommandsMixinBase):
                 consumer = args[3]
         group: StreamGroup = key.value.group_get(group_name)
         if not group:
+            if is_dragonfly:
+                raise SimpleError(msgs.XGROUP_GROUP_NOT_FOUND_MSG.format(group_name.decode(), key.key.decode()))
             raise SimpleError(msgs.XNACK_NOGROUP_MSG.format(key.key.decode(), group_name.decode()))
 
         if start is not None:
@@ -228,10 +236,15 @@ class StreamsCommandsMixin(CommandsMixinBase):
         return group.del_consumer(consumer_name)
 
     @command(name="XINFO GROUPS", fixed=(Key(XStream),), repeat=(), flags=msgs.FLAG_DO_NOT_CREATE)
-    def xinfo_groups(self, key: CommandItem) -> dict[bytes, Any]:
+    def xinfo_groups(self, key: CommandItem) -> list[dict[bytes, Any]]:
         if key.value is None:
             raise SimpleError(msgs.NO_KEY_MSG)
-        res: dict[bytes, Any] = key.value.groups_info()
+        res: list[dict[bytes, Any]] = key.value.groups_info()
+        if self.server_type == "dragonfly":
+            # Dragonfly uses -1 as its "lag unknown" sentinel and reports it as nil.
+            for group in res:
+                if group.get(b"lag") == -1:
+                    group[b"lag"] = None
         return res
 
     @command(name="XINFO STREAM", fixed=(Key(XStream),), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE)
@@ -240,6 +253,12 @@ class StreamsCommandsMixin(CommandsMixinBase):
         if key.value is None:
             raise SimpleError(msgs.NO_KEY_MSG)
         res: list[bytes] = key.value.stream_info(full)
+        if self.server_type == "dragonfly" and self._client_info.protocol_version == 3:
+            # An empty stream's first/last entry is a null array on dragonfly, where redis
+            # sends nil; under RESP3 a client reads that back as an empty array.
+            for i in range(0, len(res) - 1, 2):
+                if res[i] in (b"first-entry", b"last-entry") and res[i + 1] is None:
+                    res[i + 1] = []  # type: ignore[call-overload]
         return res
 
     @command(name="XINFO CONSUMERS", fixed=(Key(XStream), bytes), repeat=())
@@ -443,6 +462,23 @@ class StreamsCommandsMixin(CommandsMixinBase):
                 res[stream_name] = stream_results
         return res
 
+    def _empty_stream_read_reply(self, res: dict[bytes, Any] | list[Any] | None) -> dict[bytes, Any] | list[Any] | None:
+        """Shape an XREAD/XREADGROUP reply that matched nothing, under RESP3.
+
+        Redis answers with an empty map; dragonfly answers with an empty array. Note that
+        redis-py's RESP3 parser assumes the map and cannot consume dragonfly's reply.
+        Under RESP2 both send a null array, so the reply is left as it is.
+        """
+        if not res and self.server_type == "dragonfly" and self._client_info.protocol_version == 3:
+            return []
+        return res
+
+    def _xreadgroup_reply(self, res: dict[bytes, Any] | None) -> dict[bytes, Any] | list[Any] | None:
+        """Turn the streams XREADGROUP matched into the reply for the protocol in use."""
+        if self._client_info.protocol_version == 2:
+            return [[k, v] for k, v in res.items()] if res else None
+        return self._empty_stream_read_reply(res)
+
     def _xread(
         self, stream_start_id_list: list[tuple[bytes, StreamRangeTest]], count: int, blocking: bool, first_pass: bool
     ) -> None | dict[bytes, Any] | list[list[bytes | list[tuple[bytes, list[bytes]]]]]:
@@ -454,10 +490,17 @@ class StreamsCommandsMixin(CommandsMixinBase):
             if len(stream_results) > 0:
                 res[item.key] = stream_results
 
-        # On blocking read, and there are no results, return None (instead of an empty list)
-        if blocking and len(res) == 0:
-            return None
         if self._client_info.protocol_version == 2:
+            # On blocking read, and there are no results, return None (instead of an empty list)
+            if blocking and len(res) == 0:
+                return None
+            return [[k, v] for k, v in res.items()]
+        if not res:
+            # None keeps `_blocking` waiting; the caller shapes the reply once it gives up.
+            return None if blocking else res
+        if blocking and not first_pass and self.server_type == "dragonfly":
+            # A blocking read that was woken by a new entry is answered by dragonfly with the
+            # RESP2-style array, not the map it sends when the entry was already there.
             return [[k, v] for k, v in res.items()]
         return res
 

--- a/test/test_async/test_asyncredis.py
+++ b/test/test_async/test_asyncredis.py
@@ -13,6 +13,7 @@ import fakeredis
 from fakeredis import FakeServer, aioredis
 from fakeredis._typing import AsyncClientType, async_timeout
 from test import testtools
+from test.conftest import ServerDetails
 from test.testtools import resp_conversion
 
 pytestmark = []
@@ -298,14 +299,17 @@ async def test_hrandfield(async_redis: AsyncClientType):
 
 
 @pytest.mark.asyncio
-async def test_async_xread(async_redis: AsyncClientType):
+async def test_async_xread(async_redis: AsyncClientType, real_server_details: ServerDetails):
+    # Dragonfly answers a blocking XREAD woken by a new entry with the RESP2-style array,
+    # which redis-py's RESP3 parser cannot consume, so the reply is read unparsed there.
+    resp2_shape = testtools.disable_xread_parsing(async_redis, real_server_details.server_type)
     task = asyncio.create_task(async_redis.xread({"stream": "$"}, block=0))
     await asyncio.sleep(0)
     await async_redis.xadd("stream", {"data": "data"}, maxlen=1000, approximate=True)
     messages = await task
     assert len(messages) == 1
     protocol_version = testtools.get_protocol_version(async_redis)
-    if protocol_version == 2:
+    if protocol_version == 2 or resp2_shape:
         assert messages[0][0] == b"stream"
     else:
         assert b"stream" in messages

--- a/test/test_dragonfly/test_dragonfly_divergences.py
+++ b/test/test_dragonfly/test_dragonfly_divergences.py
@@ -12,6 +12,7 @@ import time
 import pytest
 
 from fakeredis._typing import ClientType
+from test import testtools
 from test.testtools import raw_command, resp_conversion
 
 pytestmark = []
@@ -83,6 +84,37 @@ def test_at_least_one_key_is_needed_for_numkeys_commands(r: ClientType):
     # Dragonfly reads numkeys as unsigned, so a negative one never decodes.
     for args in (("sintercard", -1, "s"), ("zintercard", -1, "z")):
         _raises(r, "value is not an integer or out of range", *args)
+
+
+def test_xinfo_groups_reports_unknown_lag_as_nil(r: ClientType):
+    # Dragonfly uses -1 as its "lag unknown" sentinel and reports it as nil.
+    message_id = r.xadd("stream", {"foo": "bar"})
+    r.xgroup_create("stream", "group", 0)
+    r.xgroup_setid("stream", "group", message_id, entries_read=2)
+    assert r.xinfo_groups("stream")[0]["lag"] is None
+    # A lag it can work out is reported as usual, negative ones included.
+    r.xgroup_setid("stream", "group", message_id, entries_read=5)
+    assert r.xinfo_groups("stream")[0]["lag"] == -4
+
+
+def test_xinfo_stream_reports_the_entries_of_an_empty_stream_as_a_null_array(r: ClientType):
+    # Redis sends nil, which RESP3 renders as nil; dragonfly keeps sending the RESP2 null
+    # array, so a RESP3 client reads it back as an empty array.
+    r.xadd("stream", {"foo": "bar"})
+    r.xtrim("stream", maxlen=0)
+    info = testtools.xinfo_stream_raw(r, "stream")
+    empty = testtools.null_array_reply(r, "dragonfly")
+    assert info["first-entry"] == empty
+    assert info["last-entry"] == empty
+
+
+def test_xpending_looks_the_key_up_before_the_group(r: ClientType):
+    # Redis reports both possibilities in one NOGROUP error; dragonfly checks the key
+    # first, and only names the group once the key exists.
+    _raises(r, "no such key", "xpending", "nosuchstream", "group")
+    r.xadd("stream", {"foo": "bar"})
+    err = _raises(r, "NOGROUP", "xpending", "stream", "group")
+    assert str(err) == "NOGROUP No such consumer group 'group' for key name 'stream'"
 
 
 def test_zpopmin_returns_an_array_of_pairs_under_resp3(r: ClientType):

--- a/test/test_mixins/test_streams_commands.py
+++ b/test/test_mixins/test_streams_commands.py
@@ -258,7 +258,7 @@ def test_xread_blocking_no_count(r: ClientType):
     assert m1[0][1] == {b"value": b"1234"}
 
 
-def test_xread(r: ClientType):
+def test_xread(r: ClientType, real_server_details):
     stream = "stream"
     m1 = r.xadd(stream, {"foo": "bar"})
     m2 = r.xadd(stream, {"bing": "baz"})
@@ -286,7 +286,7 @@ def test_xread(r: ClientType):
     )
 
     # xread starting at the last message returns an empty list
-    assert r.xread(streams={stream: m2}) == resp_conversion(r, {}, [])
+    testtools.assert_empty_stream_read(r, real_server_details.server_type, "XREAD", "STREAMS", stream, m2)
 
 
 def test_xread_count(r: ClientType):
@@ -373,13 +373,14 @@ def test_xgroup_create_connection7(r: ClientType):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7", max_redis_ver="8.2")
-def test_xgroup_setid_redis7(r: ClientType):
+def test_xgroup_setid_redis7(r: ClientType, real_server_details):
     stream, group = "stream", "group"
     message_id = r.xadd(stream, {"foo": "bar"})
 
     r.xgroup_create(stream, group, 0)
     # advance the last_delivered_id to the message_id
     r.xgroup_setid(stream, group, message_id, entries_read=2)
+    # Dragonfly uses -1 as its "lag unknown" sentinel and reports it as nil.
     expected = [
         {
             "name": group.encode(),
@@ -387,7 +388,7 @@ def test_xgroup_setid_redis7(r: ClientType):
             "pending": 0,
             "last-delivered-id": message_id,
             "entries-read": 2,
-            "lag": -1,
+            "lag": None if real_server_details.server_type == "dragonfly" else -1,
         }
     ]
     assert r.xinfo_groups(stream) == expected
@@ -449,7 +450,7 @@ def test_xinfo_consumers(r: ClientType):
     assert info == expected
 
 
-def test_xreadgroup(r: ClientType):
+def test_xreadgroup(r: ClientType, real_server_details):
     stream, group, consumer = "stream", "group", "consumer1"
     with pytest.raises(Exception) as ctx:
         r.xreadgroup(group, consumer, streams={stream: ">"})
@@ -490,7 +491,9 @@ def test_xreadgroup(r: ClientType):
     r.xgroup_create(stream, group, "$")
 
     # xread starting after the last message returns an empty message list
-    assert r.xreadgroup(group, consumer, streams={stream: ">"}) == resp_conversion(r, {}, [])
+    testtools.assert_empty_stream_read(
+        r, real_server_details.server_type, "XREADGROUP", "GROUP", group, consumer, "STREAMS", stream, ">"
+    )
 
     # xreadgroup with noack does not have any items in the PEL
     r.xgroup_destroy(stream, group)
@@ -521,7 +524,23 @@ def test_xreadgroup(r: ClientType):
     # TODO groups keep ids of deleted messages
     # expected = [[stream.encode(), [(m1, {}), (m2, {})]]]
     # assert r.xreadgroup(group, consumer, streams={stream: "0"}) == expected
-    r.xreadgroup(group, consumer, streams={stream: ">"}, count=10, block=500)
+    # A blocking read that finds nothing: on dragonfly under RESP3 the empty-array reply
+    # is not something redis-py can parse, so issue it raw there.
+    testtools.assert_empty_stream_read(
+        r,
+        real_server_details.server_type,
+        "XREADGROUP",
+        "GROUP",
+        group,
+        consumer,
+        "COUNT",
+        10,
+        "BLOCK",
+        500,
+        "STREAMS",
+        stream,
+        ">",
+    )
 
 
 def test_xinfo_stream(r: ClientType):
@@ -581,7 +600,7 @@ def test_xack(r: ClientType):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
-def test_xinfo_stream_redis7(r: ClientType):
+def test_xinfo_stream_redis7(r: ClientType, real_server_details):
     stream = "stream"
     m1 = r.xadd(stream, {"foo": "bar"})
     m2 = r.xadd(stream, {"foo": "bar"})
@@ -596,12 +615,17 @@ def test_xinfo_stream_redis7(r: ClientType):
     assert "last-generated-id" in info
 
     r.xtrim(stream, 0)
-    # Info about empty stream
-    info = r.xinfo_stream(stream)
+    # Info about empty stream. Dragonfly answers the missing entries with a null array
+    # where redis sends nil, which redis-py's parser cannot read, so bypass it.
+    empty_entry = testtools.null_array_reply(r, real_server_details.server_type)
+    if real_server_details.server_type == "dragonfly":
+        info = testtools.xinfo_stream_raw(r, stream)
+    else:
+        info = r.xinfo_stream(stream)
 
     assert info["length"] == 0
-    assert info["first-entry"] is None
-    assert info["last-entry"] is None
+    assert info["first-entry"] == empty_entry
+    assert info["last-entry"] == empty_entry
     assert info["max-deleted-entry-id"] == b"0-0"
     assert info["entries-added"] == 2
     assert info["recorded-first-entry-id"] == b"0-0"
@@ -632,10 +656,12 @@ def test_xinfo_groups_missing_stream(r: ClientType):
     assert not r.exists(stream)
 
 
-def test_xpending_missing_stream_or_group(r: ClientType):
+def test_xpending_missing_stream_or_group(r: ClientType, real_server_details):
     stream, group = "stream", "group"
+    # Dragonfly looks the key up before the group, so a missing stream is "no such key".
+    missing_stream_error = "no such key" if real_server_details.server_type == "dragonfly" else "NOGROUP"
 
-    with pytest.raises((redis.ResponseError, valkey.ResponseError), match="NOGROUP"):
+    with pytest.raises((redis.ResponseError, valkey.ResponseError), match=missing_stream_error):
         r.xpending(stream, group)
 
     assert not r.exists(stream)
@@ -879,7 +905,7 @@ def test_xclaim(r: ClientType):
     assert r.xclaim(stream, group, consumer1, min_idle_time=0, message_ids=(message_id,), justid=True) == [message_id]
 
 
-def test_xread_blocking(create_connection):
+def test_xread_blocking(create_connection, real_server_details):
     # thread with xread block 0 should hang
     # putting data in the stream should unblock it
     event = threading.Event()
@@ -895,11 +921,17 @@ def test_xread_blocking(create_connection):
     t = threading.Thread(target=thread_func)
     t.start()
     r1 = create_connection(db=1)
+    # Dragonfly answers a blocking XREAD woken by a new entry with the RESP2-style array,
+    # which redis-py's RESP3 parser cannot consume, so the reply is read unparsed there.
+    resp2_shape = testtools.disable_xread_parsing(r1, real_server_details.server_type)
     event.set()
     result = r1.xread({"stream": "$"}, block=0, count=1)
     event.clear()
     t.join()
-    if get_protocol_version(r1) == 2:
+    if resp2_shape:  # read unparsed, so the entry's fields come back as a flat array
+        assert result[0][0] == b"stream"
+        assert result[0][1][0][1] == [b"x", b"1"]
+    elif get_protocol_version(r1) == 2:
         assert result[0][0] == b"stream"
         assert result[0][1][0][1] == {b"x": b"1"}
     else:
@@ -948,7 +980,7 @@ def test_xreadgroup_read_2(r: ClientType):
     assert len(messages) == len(streams)
 
 
-def test_xreadgroup_pel_read(r: ClientType):
+def test_xreadgroup_pel_read(r: ClientType, real_server_details):
     stream, group, consumer = "stream", "group", "consumer1"
     c1 = {b"foo": b"bar"}
     c2 = {b"bing": b"baz"}
@@ -969,7 +1001,9 @@ def test_xreadgroup_pel_read(r: ClientType):
     assert r.xreadgroup(group, consumer, streams={stream: m1}) == resp_conversion(r, expected_resp3, expected_resp2)
 
     # PEL read does not advance last_delivered_id
-    assert r.xreadgroup(group, consumer, streams={stream: ">"}) == resp_conversion(r, {}, [])
+    testtools.assert_empty_stream_read(
+        r, real_server_details.server_type, "XREADGROUP", "GROUP", group, consumer, "STREAMS", stream, ">"
+    )
 
     # other consumer has empty PEL
     tmp = r.xreadgroup(group, "consumer2", streams={stream: "0"})

--- a/test/testtools.py
+++ b/test/testtools.py
@@ -149,3 +149,42 @@ def null_array_reply(r: redis.Redis, server_type: str) -> Any:
 def empty_blocking_reply(r: redis.Redis, server_type: str) -> Any:
     """What a timed-out BLPOP/BRPOP/BZPOPMIN looks like on the server under test."""
     return null_array_reply(r, server_type)
+
+
+def xinfo_stream_raw(r: ClientType, name: str) -> dict[str, Any]:
+    """XINFO STREAM as a str-keyed dict, bypassing redis-py's parser.
+
+    That parser assumes an empty stream's `first-entry` is nil; dragonfly answers with a
+    null array, which reads back as `[]` under RESP3 and trips the parser up.
+    """
+    reply = raw_command(r, "xinfo", "stream", name)
+    if isinstance(reply, dict):  # a RESP3 map
+        return {k.decode(): v for k, v in reply.items()}
+    return {reply[i].decode(): reply[i + 1] for i in range(0, len(reply), 2)}
+
+
+def disable_xread_parsing(r: ClientType, server_type: str) -> bool:
+    """Drop redis-py's XREAD callback when it cannot parse the reply of the server under test.
+
+    A blocking XREAD woken by a new entry is answered by dragonfly with the RESP2-style
+    array, where Redis sends a map; redis-py's RESP3 parser assumes the map. Returns whether
+    the callback was dropped, i.e. whether XREAD now answers in the RESP2 shape.
+    """
+    if server_type != "dragonfly" or get_protocol_version(r) != 3:
+        return False
+    r.response_callbacks.pop("XREAD", None)
+    return True
+
+
+def assert_empty_stream_read(r: redis.Redis, server_type: str, *raw_args: Any) -> None:
+    """Assert that an XREAD/XREADGROUP matched nothing.
+
+    Redis answers with an empty map under RESP3 and an empty array under RESP2. Dragonfly
+    answers with an empty array in both, and redis-py's RESP3 parser cannot consume that,
+    so on dragonfly the raw reply is checked instead of the parsed one.
+    """
+    if server_type == "dragonfly" and get_protocol_version(r) == 3:
+        assert raw_command(r, *raw_args) == []
+        return
+    method, args = raw_args[0], raw_args[1:]
+    assert r.execute_command(method, *args) == resp_conversion(r, {}, [])


### PR DESCRIPTION
Dragonfly's stream replies diverge in three ways that a RESP3 client notices,
and one of them redis-py cannot even parse:

* An XREAD/XREADGROUP that matched nothing answers with an empty array in both
  protocols, where Redis sends an empty map under RESP3. redis-py's RESP3
  parser assumes the map, so the tests read the raw reply on Dragonfly --
  `testtools.assert_empty_stream_read` picks the right one.
* A *blocking* XREAD woken by a new entry answers with the RESP2-style array,
  not the map it sends when the entry was already there. Same parser problem,
  handled by `testtools.disable_xread_parsing`.
* An empty stream's `first-entry`/`last-entry` is a null array rather than nil,
  which a RESP3 client reads back as `[]`, and XINFO GROUPS reports an unknown
  lag as nil (its sentinel is -1, not Redis' null).

XPENDING also looks the key up before the group, so a missing stream is "no such
key" and a missing group names only the group -- where Redis reports both in one
NOGROUP error either way.

The shaping rides on the `shape` callback `_blocking` grew in the previous
commit, since a blocking XREAD's reply is put on the queue from the async
socket's own task.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!--STACK-->
### This PR is part of a stack

`#373` split into twelve reviewable pieces. Each branches off the one above it, so they
merge in order; the diff shown here is only this step's own changes.

**#553 and #554 are merged.** #554 went into `df/01-prep` first, so master's squash commit
`b22d569e` carries both; the rest of the stack has been rebased onto master accordingly.

| PR | Branch | What it covers |
|---|--------|----------------|
| ~~#553~~ ✅ | `df/01-prep` | Server-agnostic fixes: SMOVE, BITCOUNT, GEO ordering, shared zset reply shaping |
| ~~#554~~ ✅ | `df/02-harness` | Build `FakeServer` with the Redis version Dragonfly reports; TCP server + CI plumbing |
| #555 | `df/03-errors` | Error wording and argument validation |
| #556 | `df/04-limits` | Expiry horizon, hash-field TTL cap, 256MB value cap |
| #557 | `df/05-reply-shapes` | Doubles, timed-out blocking pops, sorted-set reply shapes |
| #558 | `df/06-streams` | XREAD/XREADGROUP/XINFO/XPENDING replies |
| #559 | `df/07-pubsub` | Shard and plain channels in one namespace |
| #560 | `df/08-sort-copy-geo` | SORT patterns, COPY without DB, GEO ordering |
| #561 | `df/09-transactions` | WATCH invalidation and MULTI queueing |
| #562 | `df/10-scripting` | Lua 5.4 semantics and script error wording |
| #563 | `df/11-json` | Dragonfly's own JSON implementation |
| #564 | `df/12-hypothesis-docs` | Hypothesis guards + `docs/dragonfly-support.md` |

Verified against a real Dragonfly (`df-v1.40.1`) and a real Redis (`8.4.0`, all modules loaded): every
branch in the stack has an identical failure set to `master`, and the tip of the stack has two
*fewer* failures than `master` (PR #559 repairs a pre-existing pub/sub subscription leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
