### PR TITLE
feat(dragonfly): serve shard and plain pub/sub channels from one namespace

### DIFF
--- a/fakeredis/_msgs.py
+++ b/fakeredis/_msgs.py
@@ -43,8 +43,6 @@ WRONG_ARGS_MSG6 = "ERR wrong number of arguments for '{}' command"
 UNKNOWN_COMMAND_MSG = "ERR unknown command '{}', with args beginning with: "
 # Dragonfly reports unknown commands in its own format, without echoing the arguments back.
 DRAGONFLY_UNKNOWN_COMMAND_MSG = "ERR unknown command `{}`"
-# Dragonfly only serves the sharded pub/sub introspection subcommands in cluster mode.
-DRAGONFLY_NON_CLUSTER_MSG = "ERR PUBSUB {} is not supported in non cluster mode"
 # Raised by dragonfly for an absolute expiry deadline beyond DRAGONFLY_MAX_EXPIRE_SECONDS.
 EXPIRY_OUT_OF_RANGE_MSG = "ERR expiry is out of range"
 # Dragonfly checks the expiry option pairs separately, and accepts NX together with GT/LT.

--- a/fakeredis/_msgs.py
+++ b/fakeredis/_msgs.py
@@ -43,6 +43,8 @@ WRONG_ARGS_MSG6 = "ERR wrong number of arguments for '{}' command"
 UNKNOWN_COMMAND_MSG = "ERR unknown command '{}', with args beginning with: "
 # Dragonfly reports unknown commands in its own format, without echoing the arguments back.
 DRAGONFLY_UNKNOWN_COMMAND_MSG = "ERR unknown command `{}`"
+# Dragonfly only serves the sharded pub/sub introspection subcommands in cluster mode.
+DRAGONFLY_NON_CLUSTER_MSG = "ERR PUBSUB {} is not supported in non cluster mode"
 # Raised by dragonfly for an absolute expiry deadline beyond DRAGONFLY_MAX_EXPIRE_SECONDS.
 EXPIRY_OUT_OF_RANGE_MSG = "ERR expiry is out of range"
 # Dragonfly checks the expiry option pairs separately, and accepts NX together with GT/LT.

--- a/fakeredis/commands_mixins/pubsub_mixin.py
+++ b/fakeredis/commands_mixins/pubsub_mixin.py
@@ -8,6 +8,9 @@ from fakeredis._commands import command
 from fakeredis._helpers import NoResponse, SimpleError, compile_pattern
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
 
+# Dragonfly only serves the sharded pub/sub introspection subcommands in cluster mode.
+DRAGONFLY_NON_CLUSTER_MSG = "ERR PUBSUB {} is not supported in non cluster mode"
+
 
 class PubSubCommandsMixin(CommandsMixinBase):
     put_response: Callable[[Any], None]
@@ -131,7 +134,7 @@ class PubSubCommandsMixin(CommandsMixinBase):
         SSUBSCRIBE/SPUBLISH themselves work, only PUBSUB SHARDCHANNELS/SHARDNUMSUB are refused.
         """
         if self._server.server_type == "dragonfly":
-            raise SimpleError(msgs.DRAGONFLY_NON_CLUSTER_MSG.format(subcommand))
+            raise SimpleError(DRAGONFLY_NON_CLUSTER_MSG.format(subcommand))
 
     def _channels(self, subscribers_dict: dict[bytes, Any], *patterns: bytes) -> list[bytes]:
         channels = list(subscribers_dict.keys())

--- a/fakeredis/commands_mixins/pubsub_mixin.py
+++ b/fakeredis/commands_mixins/pubsub_mixin.py
@@ -47,6 +47,19 @@ class PubSubCommandsMixin(CommandsMixinBase):
         tuples_list = [(ch, len(subscribers.get(ch, []))) for ch in channels]
         return [item for sublist in tuples_list for item in sublist]
 
+    @property
+    def _shard_subscribers(self) -> dict[bytes, Any]:
+        """The registry SSUBSCRIBE/SPUBLISH work against.
+
+        Outside cluster mode dragonfly keeps a single channel namespace, so a sharded
+        subscription lands in the same place as a plain one: SPUBLISH then reaches plain
+        subscribers and PUBLISH reaches sharded ones. Only the message type differs, and
+        that is decided by the publishing command.
+        """
+        if self._server.server_type == "dragonfly":
+            return self._server.subscribers
+        return self._server.ssubscribers
+
     @command((bytes,), (bytes,), flags=msgs.FLAG_NO_SCRIPT)
     def psubscribe(self, *patterns: bytes) -> NoResponse:
         return self._subscribe(patterns, self._server.psubscribers, b"psubscribe")
@@ -57,7 +70,7 @@ class PubSubCommandsMixin(CommandsMixinBase):
 
     @command((bytes,), (bytes,), flags=msgs.FLAG_NO_SCRIPT)
     def ssubscribe(self, *channels: bytes) -> NoResponse:
-        return self._subscribe(channels, self._server.ssubscribers, b"ssubscribe")
+        return self._subscribe(channels, self._shard_subscribers, b"ssubscribe")
 
     @command((), (bytes,), flags=msgs.FLAG_NO_SCRIPT)
     def punsubscribe(self, *patterns: bytes) -> NoResponse:
@@ -69,7 +82,10 @@ class PubSubCommandsMixin(CommandsMixinBase):
 
     @command(fixed=(), repeat=(bytes,), flags=msgs.FLAG_NO_SCRIPT)
     def sunsubscribe(self, *channels: bytes) -> NoResponse:
-        return self._unsubscribe(channels, self._server.ssubscribers, b"sunsubscribe")
+        # Dragonfly confirms SUNSUBSCRIBE with a plain "unsubscribe" message, even though
+        # it answers SSUBSCRIBE with "ssubscribe".
+        reply = b"unsubscribe" if self._server.server_type == "dragonfly" else b"sunsubscribe"
+        return self._unsubscribe(channels, self._shard_subscribers, reply)
 
     @command((bytes, bytes))
     def publish(self, channel: bytes, message: bytes) -> int:
@@ -92,7 +108,7 @@ class PubSubCommandsMixin(CommandsMixinBase):
     def spublish(self, channel: bytes, message: bytes) -> int:
         receivers = 0
         msg = [b"smessage", channel, message]
-        subs: Iterable[Any] = self._server.ssubscribers.get(channel, set())
+        subs: Iterable[Any] = self._shard_subscribers.get(channel, set())
         for sock in subs:
             sock.put_response(msg)
             receivers += 1
@@ -109,6 +125,14 @@ class PubSubCommandsMixin(CommandsMixinBase):
     def pubsub_numpat(self, *_: Any) -> int:
         return len(self._server.psubscribers)
 
+    def _check_shard_introspection_supported(self, subcommand: str) -> None:
+        """Dragonfly rejects the sharded pub/sub introspection subcommands outside cluster mode.
+
+        SSUBSCRIBE/SPUBLISH themselves work, only PUBSUB SHARDCHANNELS/SHARDNUMSUB are refused.
+        """
+        if self._server.server_type == "dragonfly":
+            raise SimpleError(msgs.DRAGONFLY_NON_CLUSTER_MSG.format(subcommand))
+
     def _channels(self, subscribers_dict: dict[bytes, Any], *patterns: bytes) -> list[bytes]:
         channels = list(subscribers_dict.keys())
         if len(patterns) > 0:
@@ -122,7 +146,8 @@ class PubSubCommandsMixin(CommandsMixinBase):
 
     @command(name="PUBSUB SHARDCHANNELS", fixed=(), repeat=(bytes,))
     def pubsub_shardchannels(self, *args: bytes) -> list[bytes]:
-        return self._channels(self._server.ssubscribers, *args)
+        self._check_shard_introspection_supported("SHARDCHANNELS")
+        return self._channels(self._shard_subscribers, *args)
 
     @command(name="PUBSUB NUMSUB", fixed=(), repeat=(bytes,))
     def pubsub_numsub(self, *args: bytes) -> list[Any]:
@@ -130,7 +155,8 @@ class PubSubCommandsMixin(CommandsMixinBase):
 
     @command(name="PUBSUB SHARDNUMSUB", fixed=(), repeat=(bytes,))
     def pubsub_shardnumsub(self, *args: bytes) -> list[Any]:
-        return self._numsub(self._server.ssubscribers, *args)
+        self._check_shard_introspection_supported("SHARDNUMSUB")
+        return self._numsub(self._shard_subscribers, *args)
 
     @command(name="PUBSUB", fixed=())
     def pubsub(self, *args: Any) -> None:
@@ -138,7 +164,27 @@ class PubSubCommandsMixin(CommandsMixinBase):
 
     @command(name="PUBSUB HELP", fixed=())
     def pubsub_help(self, *args: Any) -> list[bytes]:
-        if self.version >= (7,):
+        if self._server.server_type == "dragonfly":
+            # Dragonfly ships its own help text, indented with tabs rather than spaces.
+            help_strings = [
+                "PUBSUB <subcommand> [<arg> [value] [opt] ...]. Subcommands are:",
+                "CHANNELS [<pattern>]",
+                "\tReturn the currently active channels matching a <pattern> (default: '*').",
+                "NUMPAT",
+                "\tReturn number of subscriptions to patterns.",
+                "NUMSUB [<channel> <channel...>]",
+                "\tReturns the number of subscribers for the specified channels, excluding",
+                "\tpattern subscriptions.",
+                "SHARDCHANNELS [pattern]",
+                "\tReturns a list of active shard channels, optionally matching the specified pattern ",
+                "(default: '*').",
+                "SHARDNUMSUB [<channel> <channel...>]",
+                "\tReturns the number of subscribers for the specified shard channels, excluding",
+                "\tpattern subscriptions.",
+                "HELP",
+                "\tPrints this help.",
+            ]
+        elif self.version >= (7,):
             help_strings = [
                 "PUBSUB <subcommand> [<arg> [value] [opt] ...]. Subcommands are:",
                 "CHANNELS [<pattern>]",

--- a/test/test_dragonfly/test_dragonfly_divergences.py
+++ b/test/test_dragonfly/test_dragonfly_divergences.py
@@ -8,6 +8,7 @@ Dragonfly counterparts, so both sides of each divergence stay covered.
 from __future__ import annotations
 
 import time
+import uuid
 
 import pytest
 
@@ -44,6 +45,16 @@ def test_lcs_is_not_supported(r: ClientType):
     assert str(err) == "unknown command `LCS`"
 
 
+@pytest.mark.parametrize("subcommand", ["SHARDCHANNELS", "SHARDNUMSUB"])
+def test_pubsub_shard_introspection_needs_cluster_mode(r: ClientType, subcommand: str):
+    _raises(r, f"PUBSUB {subcommand} is not supported in non cluster mode", "PUBSUB", subcommand)
+
+
+def test_spublish_and_ssubscribe_still_work(r: ClientType):
+    # Only the introspection subcommands are refused; sharded publishing itself works.
+    assert raw_command(r, "SPUBLISH", "chan", "msg") == 0
+
+
 def test_absolute_expiry_beyond_horizon_is_rejected(r: ClientType):
     # Dragonfly refuses a deadline more than 2**28-1 seconds away.
     horizon = 2**28 - 1
@@ -69,6 +80,68 @@ def test_expire_accepts_nx_with_gt_or_lt(r: ClientType):
     _raises(r, "NX and XX options at the same time are not compatible", "EXPIRE", "foo", 100, "NX", "XX")
     _raises(r, "GT and LT options at the same time are not compatible", "EXPIRE", "foo", 100, "GT", "LT")
     _raises(r, "Unsupported option: BOGUS", "EXPIRE", "foo", 100, "BOGUS")
+
+
+def test_sunsubscribe_is_confirmed_as_unsubscribe(r: ClientType):
+    # A unique channel: dragonfly's "unsubscribe" reply leaves redis-py's shard_channels
+    # set populated, so closing the pubsub does not reliably drop the server-side
+    # subscription and a shared name would leak into other tests.
+    channel = f"shard-{uuid.uuid4().hex}"
+    p = r.pubsub()
+    try:
+        p.ssubscribe(channel)
+        assert p.get_message(timeout=2)["type"] == "ssubscribe"
+        p.sunsubscribe()
+        # Dragonfly answers with "unsubscribe", not "sunsubscribe".
+        assert p.get_message(timeout=2)["type"] == "unsubscribe"
+    finally:
+        p.close()
+
+
+def test_pubsub_help_text(r: ClientType):
+    assert raw_command(r, "PUBSUB", "HELP") == [
+        b"PUBSUB <subcommand> [<arg> [value] [opt] ...]. Subcommands are:",
+        b"CHANNELS [<pattern>]",
+        b"\tReturn the currently active channels matching a <pattern> (default: '*').",
+        b"NUMPAT",
+        b"\tReturn number of subscriptions to patterns.",
+        b"NUMSUB [<channel> <channel...>]",
+        b"\tReturns the number of subscribers for the specified channels, excluding",
+        b"\tpattern subscriptions.",
+        b"SHARDCHANNELS [pattern]",
+        b"\tReturns a list of active shard channels, optionally matching the specified pattern ",
+        b"(default: '*').",
+        b"SHARDNUMSUB [<channel> <channel...>]",
+        b"\tReturns the number of subscribers for the specified shard channels, excluding",
+        b"\tpattern subscriptions.",
+        b"HELP",
+        b"\tPrints this help.",
+    ]
+
+
+def test_shard_and_plain_channels_share_one_namespace(r: ClientType):
+    # Outside cluster mode dragonfly has a single channel namespace: SPUBLISH reaches a
+    # plain subscriber and PUBLISH reaches a sharded one. Only the message type differs.
+    channel = f"chan-{uuid.uuid4().hex}"
+    plain, shard = r.pubsub(), r.pubsub()
+    try:
+        plain.subscribe(channel)
+        assert plain.get_message(timeout=2)["type"] == "subscribe"
+        shard.ssubscribe(channel)
+        assert shard.get_message(timeout=2)["type"] == "ssubscribe"
+
+        assert r.spublish(channel, "via-spublish") == 2
+        for p in (plain, shard):
+            msg = p.get_message(timeout=2)
+            assert (msg["type"], msg["data"]) == ("smessage", b"via-spublish")
+
+        assert r.publish(channel, "via-publish") == 2
+        for p in (plain, shard):
+            msg = p.get_message(timeout=2)
+            assert (msg["type"], msg["data"]) == ("message", b"via-publish")
+    finally:
+        plain.close()
+        shard.close()
 
 
 def test_at_least_one_key_is_needed_for_numkeys_commands(r: ClientType):

--- a/test/test_mixins/test_pubsub_commands.py
+++ b/test/test_mixins/test_pubsub_commands.py
@@ -368,6 +368,7 @@ def test_pubsub_no_subcommands(r: ClientType):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7.1")
+@pytest.mark.unsupported_server_types("dragonfly")  # dragonfly ships its own help text
 def test_pubsub_help_redis71(r: ClientType):
     assert testtools.raw_command(r, "PUBSUB HELP") == [
         b"PUBSUB <subcommand> [<arg> [value] [opt] ...]. Subcommands are:",
@@ -409,16 +410,26 @@ def test_pubsub_numsub(r: ClientType):
 @pytest.mark.supported_server_versions(min_redis_ver="7")
 @testtools.run_test_if_redispy_ver("gte", "5.0.0rc2")
 def test_published_message_to_shard_channel(r: ClientType):
+    # A unique channel, and an explicit close: dragonfly serves shard and plain channels
+    # from one namespace, so any subscriber another test left on a shared name would be
+    # counted by SPUBLISH here.
+    channel = f"shard-{uuid.uuid4().hex}"
     p = r.pubsub()
-    p.ssubscribe("foo")
-    assert wait_for_message(p) == make_message("ssubscribe", "foo", 1)
-    assert r.spublish("foo", "test message") == 1
+    try:
+        p.ssubscribe(channel)
+        assert wait_for_message(p) == make_message("ssubscribe", channel, 1)
+        assert r.spublish(channel, "test message") == 1
 
-    message = wait_for_message(p)
-    assert isinstance(message, dict)
-    assert message == make_message("smessage", "foo", "test message")
+        message = wait_for_message(p)
+        assert isinstance(message, dict)
+        assert message == make_message("smessage", channel, "test message")
+    finally:
+        p.close()
 
 
+# Dragonfly confirms SUNSUBSCRIBE with a plain "unsubscribe", so redis-py never clears its
+# shard_channels bookkeeping and `subscribed` stays True. See test_dragonfly for that behaviour.
+@pytest.mark.unsupported_server_types("dragonfly")
 @pytest.mark.supported_server_versions(min_redis_ver="7")
 @testtools.run_test_if_redispy_ver("gte", "5.0.0rc2")
 def test_subscribe_property_with_shard_channels_cluster(r: ClientType):
@@ -465,6 +476,7 @@ def test_subscribe_property_with_shard_channels_cluster(r: ClientType):
     assert p.subscribed is False
 
 
+@pytest.mark.unsupported_server_types("dragonfly")  # PUBSUB SHARD* needs cluster mode
 @pytest.mark.supported_server_versions(min_redis_ver="7")
 @testtools.run_test_if_redispy_ver("gte", "5.0.0")
 def test_pubsub_shardnumsub(r: ClientType):
@@ -485,6 +497,7 @@ def test_pubsub_shardnumsub(r: ClientType):
     assert r.pubsub_shardnumsub("foo", "bar", "baz", target_nodes="all") == channels
 
 
+@pytest.mark.unsupported_server_types("dragonfly")  # PUBSUB SHARD* needs cluster mode
 @pytest.mark.supported_server_versions(min_redis_ver="7")
 @testtools.run_test_if_redispy_ver("gte", "5.0.0rc2")
 def test_pubsub_shardchannels(r: ClientType):


### PR DESCRIPTION
Outside cluster mode Dragonfly keeps a single channel namespace, so a sharded
subscription lands in the same registry as a plain one: SPUBLISH reaches plain
subscribers and PUBLISH reaches sharded ones. Only the message type differs, and
that is decided by the publishing command rather than by how the subscriber
signed up.

Following from that, and from the same non-cluster mode:

* PUBSUB SHARDCHANNELS and SHARDNUMSUB are refused outright -- "not supported in
  non cluster mode" -- even though SSUBSCRIBE and SPUBLISH themselves work.
* SUNSUBSCRIBE is confirmed with a plain `unsubscribe` message, though
  SSUBSCRIBE is still confirmed with `ssubscribe`. redis-py takes the
  confirmation at face value and never clears its `shard_channels` bookkeeping,
  so `pubsub.subscribed` stays True there; the Redis-flavoured test for that is
  excluded on Dragonfly rather than taught to expect it.
* PUBSUB HELP ships Dragonfly's own text, indented with tabs.

The shared namespace has a testing consequence worth knowing about: a subscriber
another test left behind on a common channel name is counted by an SPUBLISH
here, which is why `test_published_message_to_shard_channel` now uses a unique
channel and closes its pubsub explicitly.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!--STACK-->
### This PR is part of a stack

`#373` split into twelve reviewable pieces. Each branches off the one above it, so they
merge in order; the diff shown here is only this step's own changes.

**#553 and #554 are merged.** #554 went into `df/01-prep` first, so master's squash commit
`b22d569e` carries both; the rest of the stack has been rebased onto master accordingly.

| PR | Branch | What it covers |
|---|--------|----------------|
| ~~#553~~ ✅ | `df/01-prep` | Server-agnostic fixes: SMOVE, BITCOUNT, GEO ordering, shared zset reply shaping |
| ~~#554~~ ✅ | `df/02-harness` | Build `FakeServer` with the Redis version Dragonfly reports; TCP server + CI plumbing |
| #555 | `df/03-errors` | Error wording and argument validation |
| #556 | `df/04-limits` | Expiry horizon, hash-field TTL cap, 256MB value cap |
| #557 | `df/05-reply-shapes` | Doubles, timed-out blocking pops, sorted-set reply shapes |
| #558 | `df/06-streams` | XREAD/XREADGROUP/XINFO/XPENDING replies |
| #559 | `df/07-pubsub` | Shard and plain channels in one namespace |
| #560 | `df/08-sort-copy-geo` | SORT patterns, COPY without DB, GEO ordering |
| #561 | `df/09-transactions` | WATCH invalidation and MULTI queueing |
| #562 | `df/10-scripting` | Lua 5.4 semantics and script error wording |
| #563 | `df/11-json` | Dragonfly's own JSON implementation |
| #564 | `df/12-hypothesis-docs` | Hypothesis guards + `docs/dragonfly-support.md` |

Verified against a real Dragonfly (`df-v1.40.1`) and a real Redis (`8.4.0`, all modules loaded): every
branch in the stack has an identical failure set to `master`, and the tip of the stack has two
*fewer* failures than `master` (PR #559 repairs a pre-existing pub/sub subscription leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
