### PR TITLE
feat(dragonfly): match its SORT, COPY and GEO behaviour

### DIFF
--- a/fakeredis/commands_mixins/generic_mixin.py
+++ b/fakeredis/commands_mixins/generic_mixin.py
@@ -48,6 +48,13 @@ class GenericCommandsMixin(CommandsMixinBase):
         """Python implementation of lookupKeyByPattern from redis"""
         if pattern == b"#":
             return key
+        if self.server_type == "dragonfly":
+            # Dragonfly substitutes the '*' into a plain key name. It neither requires the
+            # pattern to contain a '*' nor understands redis' '->' hash-field syntax, so
+            # "w_*->f" resolves to the literal key "w_<element>->f".
+            new_key = pattern.replace(b"*", key, 1)
+            value = CommandItem(new_key, self._db, item=self._db.get(new_key)).value
+            return value if isinstance(value, bytes) else None
         p = pattern.find(b"*")
         if p == -1:
             return None
@@ -297,20 +304,24 @@ class GenericCommandsMixin(CommandsMixinBase):
             def sort_key_score(val: bytes) -> tuple[float, bytes]:
                 byval = self._lookup_key(val, sortby)
                 score = SortFloat.decode(byval) if byval is not None else 0.0
-                return score, val
+                # Redis breaks ties on the element itself, while dragonfly sorts on the weight alone and so leaves
+                # equally weighted elements in their order.
+                return (score, b"") if self.server_type == "dragonfly" else (score, val)
 
             sort_func = sort_key if alpha else sort_key_score
             items.sort(key=sort_func, reverse=desc)
         # A `BY` pattern with no `*` means "don't sort": keep natural order (insertion order for lists, score order for
-        # zsets) and only reverse when DESC is given.
-        elif desc and isinstance(key.value, (list, ZSet)):
+        # zsets) and only reverse when DESC is given. Dragonfly ignores DESC in this case.
+        elif desc and isinstance(key.value, (list, ZSet)) and self.server_type != "dragonfly":
             items.reverse()
 
         out = []
+        # Dragonfly reports an unresolvable GET pattern as an empty string rather than nil.
+        empty_get = store is not None or self.server_type == "dragonfly"
         for row in items[start:end]:
             for g in get:
                 v = self._lookup_key(row, g)
-                if store is not None and v is None:
+                if v is None and empty_get:
                     v = b""
                 out.append(v)
         if store is not None:
@@ -371,20 +382,24 @@ class GenericCommandsMixin(CommandsMixinBase):
             def sort_key_score(val: bytes) -> tuple[float, bytes]:
                 byval = self._lookup_key(val, sortby)
                 score = SortFloat.decode(byval) if byval is not None else 0.0
-                return score, val
+                # Redis breaks ties on the element itself, while dragonfly sorts on the weight alone and so leaves
+                # equally weighted elements in their order.
+                return (score, b"") if self.server_type == "dragonfly" else (score, val)
 
             sort_func = sort_key if alpha else sort_key_score
             items.sort(key=sort_func, reverse=desc)
         # A `BY` pattern with no `*` means "don't sort": keep natural order (insertion order for lists, score order for
-        # zsets) and only reverse when DESC is given.
-        elif desc and isinstance(key.value, (list, ZSet)):
+        # zsets) and only reverse when DESC is given. Dragonfly ignores DESC in this case.
+        elif desc and isinstance(key.value, (list, ZSet)) and self.server_type != "dragonfly":
             items.reverse()
 
         out: list[bytes] = []
+        is_dragonfly = self.server_type == "dragonfly"
         for row in items[start:end]:
             for g in get:
                 v = self._lookup_key(row, g)
-                out.append(v)  # type:ignore
+                # Dragonfly reports an unresolvable GET pattern as an empty string, not nil.
+                out.append(b"" if v is None and is_dragonfly else v)  # type:ignore
         return out
 
     @command(name="TTL", fixed=(Key(),))
@@ -401,6 +416,9 @@ class GenericCommandsMixin(CommandsMixinBase):
 
     @command(name="COPY", fixed=(Key(), Key()), repeat=(bytes,))
     def copy(self, key: CommandItem, newkey: CommandItem, *args: bytes) -> int:
+        if self._server.server_type == "dragonfly" and any(casematch(arg, b"db") for arg in args):
+            # Dragonfly's COPY has no DB option at all, so it never even parses the index.
+            raise SimpleError(msgs.SYNTAX_ERROR_MSG)
         (db_num, replace), _ = extract_args(args, ("+db", "replace"))
         if db_num is not None and not DbIndex.MIN_VALUE <= db_num <= DbIndex.MAX_VALUE:
             raise SimpleError(msgs.INVALID_DB_MSG)

--- a/fakeredis/commands_mixins/geo_mixin.py
+++ b/fakeredis/commands_mixins/geo_mixin.py
@@ -59,6 +59,7 @@ def _find_near(
     count: int,
     count_any: bool,
     desc: bool,
+    sort: bool = True,
 ) -> list[GeoResult]:
     """Find items within area (lat,long)+radius
     :param zset: list of items to check
@@ -69,6 +70,8 @@ def _find_near(
     :param count: number of results to give
     :param count_any: should we return any results that match? (vs. sorted)
     :param desc: should results be sorted descending order?
+    :param sort: should results be ordered by distance at all? Dragonfly only orders them
+        when ASC/DESC is given explicitly, otherwise it answers in geohash (score) order.
     :returns: List of GeoResults
     """
     results = []
@@ -83,7 +86,8 @@ def _find_near(
             results.append(GeoResult(name, p_long, p_lat, _hash, dist))
             if count_any and len(results) >= count:
                 break
-    results = sorted(results, key=lambda x: x.distance, reverse=desc)
+    if sort:
+        results = sorted(results, key=lambda x: x.distance, reverse=desc)
     if count:
         results = results[:count]
     return results
@@ -100,15 +104,26 @@ class GeoCommandsMixin(CommandsMixinBase):
         return len(geo_results)
 
     def _georadius(self, key: CommandItem, long: float, lat: float, radius: float, *args: bytes) -> list[bytes] | int:
-        (withcoord, withdist, _withhash, count, count_any, desc, store, storedist), _left_args = extract_args(
+        (withcoord, withdist, _withhash, count, count_any, asc, desc, store, storedist), _left_args = extract_args(
             args,
-            ("withcoord", "withdist", "withhash", "+count", "any", "desc", "*store", "*storedist"),
+            ("withcoord", "withdist", "withhash", "+count", "any", "asc", "desc", "*store", "*storedist"),
             error_on_unexpected=False,
             left_from_first_unexpected=False,
         )
         count = count or sys.maxsize
         conv = translate_meters_to_unit(args[0]) if len(args) >= 1 else 1
-        geo_results: list[GeoResult] = _find_near(key.value, lat, long, radius, conv, count, count_any, desc)
+        geo_results: list[GeoResult] = _find_near(
+            key.value,
+            lat,
+            long,
+            radius,
+            conv,
+            count,
+            count_any,
+            desc,
+            # Dragonfly only orders by distance when ASC/DESC is explicit.
+            sort=self.server_type != "dragonfly" or asc or desc,
+        )
 
         if store:
             self._store_geo_results(store, geo_results, scoredist=False)
@@ -168,15 +183,26 @@ class GeoCommandsMixin(CommandsMixinBase):
 
     @command(name="GEORADIUS_RO", fixed=(Key(ZSet), Float, Float, Float), repeat=(bytes,))
     def georadius_ro(self, key: CommandItem, long: float, lat: float, radius: float, *args: bytes) -> list[Any]:
-        (withcoord, withdist, _withhash, count, count_any, desc), _left_args = extract_args(
+        (withcoord, withdist, _withhash, count, count_any, asc, desc), _left_args = extract_args(
             args,
-            ("withcoord", "withdist", "withhash", "+count", "any", "desc"),
+            ("withcoord", "withdist", "withhash", "+count", "any", "asc", "desc"),
             error_on_unexpected=False,
             left_from_first_unexpected=False,
         )
         count = count or sys.maxsize
         conv: float = translate_meters_to_unit(args[0]) if len(args) >= 1 else 1.0
-        geo_results = _find_near(key.value, lat, long, radius, conv, count, count_any, desc)
+        geo_results = _find_near(
+            key.value,
+            lat,
+            long,
+            radius,
+            conv,
+            count,
+            count_any,
+            desc,
+            # Dragonfly only orders by distance when ASC/DESC is explicit.
+            sort=self.server_type != "dragonfly" or asc or desc,
+        )
 
         ret = _parse_results(geo_results, withcoord, withdist)
         return ret

--- a/test/test_dragonfly/test_dragonfly_divergences.py
+++ b/test/test_dragonfly/test_dragonfly_divergences.py
@@ -55,6 +55,17 @@ def test_spublish_and_ssubscribe_still_work(r: ClientType):
     assert raw_command(r, "SPUBLISH", "chan", "msg") == 0
 
 
+def test_copy_has_no_db_option(r: ClientType):
+    r.set("src", "val")
+    for db in ("0", "1", "-1", "not-a-db"):
+        _raises(r, "syntax error", "COPY", "src", "dst", "DB", db)
+    # ...but a plain COPY works, and carries the TTL over.
+    r.expire("src", 100)
+    assert r.copy("src", "dst") is True
+    assert r.get("dst") == b"val"
+    assert 0 < r.ttl("dst") <= 100
+
+
 def test_absolute_expiry_beyond_horizon_is_rejected(r: ClientType):
     # Dragonfly refuses a deadline more than 2**28-1 seconds away.
     horizon = 2**28 - 1
@@ -80,6 +91,38 @@ def test_expire_accepts_nx_with_gt_or_lt(r: ClientType):
     _raises(r, "NX and XX options at the same time are not compatible", "EXPIRE", "foo", 100, "NX", "XX")
     _raises(r, "GT and LT options at the same time are not compatible", "EXPIRE", "foo", 100, "GT", "LT")
     _raises(r, "Unsupported option: BOGUS", "EXPIRE", "foo", 100, "BOGUS")
+
+
+def test_sort_has_no_hash_field_patterns(r: ClientType):
+    # "record_*->age" is taken as a literal key name rather than a hash field reference.
+    r.rpush("foo", "middle", "eldest", "youngest")
+    for name, age in (("youngest", 1), ("middle", 10), ("eldest", 20)):
+        r.hset(f"record_{name}", "age", age)
+    assert r.sort("foo", by="record_*->age") == [b"middle", b"eldest", b"youngest"]
+    assert r.sort("foo", by="record_*->age", get="record_*->name") == [b"", b"", b""]
+
+
+def test_sort_by_nosort_ignores_desc(r: ClientType):
+    natural = [b"3", b"1", b"2", b"5", b"4"]
+    r.rpush("mylist", *natural)
+    assert r.sort("mylist", by="nosort") == natural
+    assert r.sort("mylist", by="nosort", desc=True) == natural
+
+
+def test_sort_get_pattern_without_star_is_a_literal_key(r: ClientType):
+    r.rpush("mylist", "a", "b")
+    r.set("lit", "LITVAL")
+    assert r.sort("mylist", by="nosort", get="lit") == [b"LITVAL", b"LITVAL"]
+    # An unresolvable GET yields an empty string rather than nil.
+    assert r.sort("mylist", by="nosort", get="missing_*") == [b"", b""]
+
+
+def test_sort_leaves_equal_weights_in_place(r: ClientType):
+    # Redis breaks ties on the element itself; dragonfly sorts on the weight alone.
+    r.rpush("l", "zebra", "apple", "mango")
+    for element in ("zebra", "apple", "mango"):
+        r.set(f"w_{element}", "5")
+    assert r.sort("l", by="w_*") == [b"zebra", b"apple", b"mango"]
 
 
 def test_sunsubscribe_is_confirmed_as_unsubscribe(r: ClientType):

--- a/test/test_mixins/test_generic_commands.py
+++ b/test/test_mixins/test_generic_commands.py
@@ -189,7 +189,7 @@ def test_sort_with_store_option(r: ClientType):
     assert r.lrange("bar", 0, -1) == [b"1", b"2", b"3", b"4"]
 
 
-def test_sort_with_by_and_get_option(r: ClientType):
+def test_sort_with_by_and_get_option(r: ClientType, real_server_details):
     r.rpush("foo", "2")
     r.rpush("foo", "1")
     r.rpush("foo", "4")
@@ -217,7 +217,11 @@ def test_sort_with_by_and_get_option(r: ClientType):
         b"one",
         b"1",
     ]
-    assert r.sort("foo", by="weight_*", get="data_1") == [None, None, None, None]
+    # A GET pattern with no `*` yields nil on redis, but dragonfly looks the literal key up.
+    if real_server_details.server_type == "dragonfly":
+        assert r.sort("foo", by="weight_*", get="data_1") == [b"one"] * 4
+    else:
+        assert r.sort("foo", by="weight_*", get="data_1") == [None, None, None, None]
     # Test sort with different parameters order
     assert raw_command(r, "sort", "foo", "get", "data_*", "by", "weight_*", "get", "#") == [
         b"four",
@@ -231,12 +235,14 @@ def test_sort_with_by_and_get_option(r: ClientType):
     ]
 
 
-def test_sort_by_nosort_keeps_natural_order(r: ClientType):
+def test_sort_by_nosort_keeps_natural_order(r: ClientType, real_server_details):
     # A `BY` pattern with no `*` disables sorting: redis returns elements in natural order (insertion order for lists,
-    # score order for sorted sets) and reverses only when DESC is given.
-    r.rpush("mylist", "3", "1", "2", "5", "4")
-    assert r.sort("mylist", by="nosort") == [b"3", b"1", b"2", b"5", b"4"]
-    assert r.sort("mylist", by="nosort", desc=True) == [b"4", b"5", b"2", b"1", b"3"]
+    # score order for sorted sets) and reverses only when DESC is given. Dragonfly ignores DESC here.
+    natural = [b"3", b"1", b"2", b"5", b"4"]
+    r.rpush("mylist", *natural)
+    assert r.sort("mylist", by="nosort") == natural
+    is_dragonfly = real_server_details.server_type == "dragonfly"
+    assert r.sort("mylist", by="nosort", desc=True) == (natural if is_dragonfly else natural[::-1])
     # LIMIT must apply to the natural-order list, not a reversed one.
     assert r.sort("mylist", by="nosort", start=1, num=2) == [b"1", b"2"]
 
@@ -244,7 +250,7 @@ def test_sort_by_nosort_keeps_natural_order(r: ClientType):
     assert r.sort("myzset", by="nosort") == [b"b", b"c", b"a"]
 
 
-def test_sort_with_hash(r: ClientType):
+def test_sort_with_hash(r: ClientType, real_server_details):
     r.rpush("foo", "middle")
     r.rpush("foo", "eldest")
     r.rpush("foo", "youngest")
@@ -257,8 +263,14 @@ def test_sort_with_hash(r: ClientType):
     r.hset("record_eldest", "age", 20)
     r.hset("record_eldest", "name", "adult")
 
-    assert r.sort("foo", by="record_*->age") == [b"youngest", b"middle", b"eldest"]
-    assert r.sort("foo", by="record_*->age", get="record_*->name") == [b"baby", b"teen", b"adult"]
+    if real_server_details.server_type == "dragonfly":
+        # Dragonfly has no `->` hash-field syntax: "record_*->age" is taken as a literal key
+        # name, so no weight resolves, the list keeps its natural order and GET yields "".
+        assert r.sort("foo", by="record_*->age") == [b"middle", b"eldest", b"youngest"]
+        assert r.sort("foo", by="record_*->age", get="record_*->name") == [b"", b"", b""]
+    else:
+        assert r.sort("foo", by="record_*->age") == [b"youngest", b"middle", b"eldest"]
+        assert r.sort("foo", by="record_*->age", get="record_*->name") == [b"baby", b"teen", b"adult"]
 
 
 def test_sort_with_set(r: ClientType):
@@ -808,6 +820,7 @@ def test_copy_replaces_with_expiry(r: ClientType, real_server_details):
     assert r.expiretime("bar") == expire_at
 
 
+@pytest.mark.unsupported_server_types("dragonfly")  # dragonfly COPY has no DB option
 @pytest.mark.supported_server_versions(min_redis_ver="7")
 def test_copy_db_replaces_with_expire(r: ClientType):
     r.set("foo", "0")
@@ -830,6 +843,7 @@ def test_copy_db_replaces_with_expire(r: ClientType):
     assert r.expiretime("bar") == 33177117420
 
 
+@pytest.mark.unsupported_server_types("dragonfly")  # dragonfly COPY has no DB option
 def test_copy_invalid_db(r: ClientType):
     r.set("foo", "0")
     assert r.copy("foo", "bar", destination_db="1") == 1
@@ -841,6 +855,7 @@ def test_copy_invalid_db(r: ClientType):
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 
 
+@pytest.mark.unsupported_server_types("dragonfly")  # dragonfly COPY has no DB option
 def test_copy_non_existing_key(r: ClientType):
     r.set("foo", "0")
     assert r.copy("bar", "baz", destination_db="1") == 0
@@ -852,6 +867,7 @@ def test_copy_non_existing_key(r: ClientType):
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 
 
+@pytest.mark.unsupported_server_types("dragonfly")  # dragonfly COPY has no DB option
 def test_copy_same_db(r: ClientType):
     r.select(1)
     r.set("foo", "0")
@@ -860,6 +876,7 @@ def test_copy_same_db(r: ClientType):
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 
 
+@pytest.mark.unsupported_server_types("dragonfly")  # dragonfly COPY has no DB option
 @pytest.mark.supported_server_versions(min_redis_ver="6.2")
 def test_copy_db_index_out_of_range(r: ClientType):
     r.set("foo", "0")
@@ -870,6 +887,7 @@ def test_copy_db_index_out_of_range(r: ClientType):
     assert r.exists("bar") == 0
 
 
+@pytest.mark.unsupported_server_types("dragonfly")  # dragonfly COPY has no DB option
 @pytest.mark.supported_server_versions(min_redis_ver="6.2")
 def test_copy_to_db_0(r: ClientType):
     # the test connection uses db 2; an explicit DB 0 must not fall back to the current db

--- a/test/test_mixins/test_geo_commands.py
+++ b/test/test_mixins/test_geo_commands.py
@@ -206,7 +206,7 @@ def test_georadius_errors(r: ClientType):
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 
 
-def test_geosearch(r: ClientType):
+def test_geosearch(r: ClientType, real_server_details):
     values = (
         2.1909389952632,
         41.433791470673,
@@ -224,7 +224,16 @@ def test_geosearch(r: ClientType):
     # assert r.geosearch("barcelona", longitude=2.191, latitude=41.433, height=1000, width=1000) == [b"place1"]
     assert set(r.geosearch("barcelona", member="place3", radius=100, unit="km")) == {b"place2", b"place1", b"place3"}
     # test count
-    assert r.geosearch("barcelona", member="place3", radius=100, unit="km", count=2) == [b"place3", b"place2"]
+    if real_server_details.server_type == "dragonfly":
+        # COUNT alone does not imply an ascending sort on dragonfly: results come back in
+        # geohash (sorted-set score) order unless ASC/DESC is asked for explicitly.
+        assert r.geosearch("barcelona", member="place3", radius=100, unit="km", count=2) == [b"place2", b"place1"]
+        assert r.geosearch("barcelona", member="place3", radius=100, unit="km", count=2, sort="ASC") == [
+            b"place3",
+            b"place2",
+        ]
+    else:
+        assert r.geosearch("barcelona", member="place3", radius=100, unit="km", count=2) == [b"place3", b"place2"]
     assert r.geosearch("barcelona", member="place3", radius=100, unit="km", count=1, any=True)[0] in [
         b"place1",
         b"place3",


### PR DESCRIPTION
SORT is where the two servers differ most, and all of it follows from Dragonfly
having a simpler pattern resolver:

* There is no `->` hash-field syntax. `record_*->age` is substituted into a
  literal key name, so nothing resolves, the list keeps its natural order, and
  GET yields the empty string.
* A pattern is not required to contain a `*` either, so `GET data_1` looks up
  the literal key `data_1` rather than answering nil.
* An unresolvable GET pattern is reported as an empty string, not nil -- the
  behaviour Redis only has when STORE is given.
* Weights are sorted on their own, without Redis' tie-break on the element
  itself, so equally weighted elements keep their relative order.
* `BY nosort` ignores DESC entirely.

COPY has no DB option at all, so it never parses the index and reports the
option as a plain syntax error; the Redis tests that exercise cross-database
copying are excluded rather than rewritten.

GEORADIUS/GEOSEARCH only order by distance when ASC or DESC is given
explicitly -- otherwise the reply comes back in geohash order, which is why the
previous commit made `_find_near` walk the sorted set in score order.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!--STACK-->
### This PR is part of a stack

`#373` split into twelve reviewable pieces. Each branches off the one above it, so they
merge in order; the diff shown here is only this step's own changes.

**#553 and #554 are merged.** #554 went into `df/01-prep` first, so master's squash commit
`b22d569e` carries both; the rest of the stack has been rebased onto master accordingly.

| PR | Branch | What it covers |
|---|--------|----------------|
| ~~#553~~ ✅ | `df/01-prep` | Server-agnostic fixes: SMOVE, BITCOUNT, GEO ordering, shared zset reply shaping |
| ~~#554~~ ✅ | `df/02-harness` | Build `FakeServer` with the Redis version Dragonfly reports; TCP server + CI plumbing |
| #555 | `df/03-errors` | Error wording and argument validation |
| #556 | `df/04-limits` | Expiry horizon, hash-field TTL cap, 256MB value cap |
| #557 | `df/05-reply-shapes` | Doubles, timed-out blocking pops, sorted-set reply shapes |
| #558 | `df/06-streams` | XREAD/XREADGROUP/XINFO/XPENDING replies |
| #559 | `df/07-pubsub` | Shard and plain channels in one namespace |
| #560 | `df/08-sort-copy-geo` | SORT patterns, COPY without DB, GEO ordering |
| #561 | `df/09-transactions` | WATCH invalidation and MULTI queueing |
| #562 | `df/10-scripting` | Lua 5.4 semantics and script error wording |
| #563 | `df/11-json` | Dragonfly's own JSON implementation |
| #564 | `df/12-hypothesis-docs` | Hypothesis guards + `docs/dragonfly-support.md` |

Verified against a real Dragonfly (`df-v1.40.1`) and a real Redis (`8.4.0`, all modules loaded): every
branch in the stack has an identical failure set to `master`, and the tip of the stack has two
*fewer* failures than `master` (PR #559 repairs a pre-existing pub/sub subscription leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
