### PR TITLE
feat(dragonfly): dirty a watched key on any write, and end a transaction that fails to queue

### DIFF
--- a/fakeredis/_basefakesocket.py
+++ b/fakeredis/_basefakesocket.py
@@ -12,7 +12,7 @@ from typing import Any, AnyStr, Callable, ClassVar
 
 import redis
 
-from fakeredis.model import BaseModel, ClientInfo, Hash
+from fakeredis.model import BaseModel, ClientInfo, Hash, is_write_command
 
 from . import _msgs as msgs
 from ._command_args_parsing import extract_args
@@ -30,6 +30,33 @@ from ._helpers import (
 from ._typing import ResponseErrorType, ServerType, VersionType
 
 LOGGER = logging.getLogger("fakeredis")
+
+# Dragonfly refuses to queue the (un)subscribe family inside a MULTI, where redis queues it.
+DRAGONFLY_NO_TRANSACTION_COMMANDS = frozenset(
+    {"subscribe", "unsubscribe", "psubscribe", "punsubscribe", "ssubscribe", "sunsubscribe"}
+)
+# Write commands whose keys dragonfly leaves clean unless it really wrote them: the ones that
+# only read the keys beside their destination, and the two that bow out before touching the
+# key at all -- a rejected MSETNX and a SETRANGE with an empty value. See `_dirty_watched_keys`.
+DRAGONFLY_UNDIRTIED_COMMANDS = frozenset(
+    {
+        "bitop",
+        "copy",
+        "georadius",
+        "georadiusbymember",
+        "geosearchstore",
+        "msetnx",
+        "sdiffstore",
+        "setrange",
+        "sinterstore",
+        "sort",
+        "sunionstore",
+        "zdiffstore",
+        "zinterstore",
+        "zrangestore",
+        "zunionstore",
+    }
+)
 
 
 def _convert_to_resp2(val: Any, server_type: ServerType = "redis", keep_doubles: bool = False) -> Any:
@@ -88,6 +115,9 @@ def _get_next_file_no() -> int:
 
 class BaseFakeSocket:
     _clear_watches: Callable[[], None]
+    abort_transaction: Callable[[], None]
+    _forget_transaction: Callable[[], None]
+    _queueing: bool
     ACCEPTED_COMMANDS_WHILE_PUBSUB: ClassVar[set[str]] = {
         "ping",
         "subscribe",
@@ -144,6 +174,7 @@ class BaseFakeSocket:
         self._in_transaction: bool
         self._pubsub: int
         self._transaction_failed: bool
+        self._transaction_paused: bool
         info.update(
             {
                 "id": self._server.get_next_client_id(),
@@ -285,8 +316,13 @@ class BaseFakeSocket:
         result: Any
         cmd, cmd_arguments = _extract_command(fields)
         from_run_command = False
+        unknown_command = False
         try:
-            func, sig = self._name_to_func(cmd)
+            try:
+                func, sig = self._name_to_func(cmd)
+            except SimpleError:
+                unknown_command = True
+                raise
             # ACL check
             self._server.acl.validate_command(self._client_info.user, self._client_info.as_bytes(), fields)
             with self._server.lock:
@@ -304,19 +340,26 @@ class BaseFakeSocket:
                 for db in self._server.dbs.values():
                     db.time = now
                 sig.check_arity(cmd_arguments, self.version)
-                if self._transaction is not None and msgs.FLAG_TRANSACTION not in sig.flags:
+                if self._queueing and self._transaction is not None and msgs.FLAG_TRANSACTION not in sig.flags:
+                    if self.server_type == "dragonfly" and cmd in DRAGONFLY_NO_TRANSACTION_COMMANDS:
+                        raise SimpleError(msgs.DRAGONFLY_NOT_IN_TRANSACTION_MSG.format(cmd.upper()))
                     self._transaction.append((func, sig, cmd_arguments))
                     result = QUEUED
                 else:
                     from_run_command = True
                     result = self._run_command(func, sig, cmd_arguments, False)
         except SimpleError as exc:
-            if self._transaction is not None and not from_run_command:
-                self._transaction_failed = True
+            if self._queueing and not from_run_command:
+                if self.server_type != "dragonfly":
+                    self._transaction_failed = True
+                elif not unknown_command:
+                    # Dragonfly stops queueing as soon as a command fails to queue, rather
+                    # than queueing on and refusing the EXEC. An unknown command is the one
+                    # exception: there the transaction carries on unharmed.
+                    self.abort_transaction()
             if cmd == "exec" and exc.value.startswith("ERR "):
                 exc.value = "EXECABORT Transaction discarded because of: " + exc.value[4:]
-                self._transaction = None
-                self._transaction_failed = False
+                self._forget_transaction()
                 self._clear_watches()
             result = exc
         result = self._decode_result(result)
@@ -333,6 +376,7 @@ class BaseFakeSocket:
     ) -> Any:
         command_items: list[CommandItem] = []
         self._subkey_events = []
+        is_dragonfly = self.server_type == "dragonfly"
         try:
             ret = sig.apply(args, self._db, self.version)
             if from_script and msgs.FLAG_NO_SCRIPT in sig.flags:
@@ -354,6 +398,8 @@ class BaseFakeSocket:
             result = exc
         for command_item in command_items:
             command_item.writeback(remove_empty_val=msgs.FLAG_LEAVE_EMPTY_VAL not in sig.flags)
+        if is_dragonfly:
+            self._dirty_watched_keys(sig, command_items)
         self._keyspace_notifications(command_items, sig.name.encode())
         self._subkey_notifications(command_items)
         return result
@@ -509,6 +555,21 @@ class BaseFakeSocket:
         reason, self._unblock_reason = self._unblock_reason, None
         if reason == b"error":
             raise SimpleError(msgs.UNBLOCKED_MSG)
+
+    def _dirty_watched_keys(self, sig: Signature, command_items: list[CommandItem]) -> None:
+        """Invalidate the watches dragonfly invalidates and redis does not.
+
+        Dragonfly dirties every key a write command runs against, so a `SET NX` that was
+        rejected, or a `SREM` that removed nothing, still breaks a `WATCH` on the key. A
+        key that does not exist stays clean, as do the keys of the commands listed in
+        `DRAGONFLY_UNDIRTIED_COMMANDS`.
+        """
+        name = sig.name.split(" ")[0]
+        if name in DRAGONFLY_UNDIRTIED_COMMANDS or not is_write_command(name.encode()):
+            return
+        for item in command_items:
+            if not item.is_modified and self._db.has_watch(item.key) and item.key in self._db:
+                self._db.notify_watch(item.key)
 
     def _name_to_func(self, cmd_name: str) -> tuple[Callable[[Any], Any] | None, Signature]:
         """Get the signature and the method from the command name."""

--- a/fakeredis/_helpers.py
+++ b/fakeredis/_helpers.py
@@ -168,6 +168,10 @@ class Database(MutableMapping):  # type: ignore
         for callback in self._change_callbacks:
             callback()
 
+    def has_watch(self, key: bytes) -> bool:
+        """Whether any client is watching `key`."""
+        return bool(self._watches.get(key))
+
     def add_watch(self, key: bytes, sock: Any) -> None:
         self._watches[key].add(sock)
 

--- a/fakeredis/_msgs.py
+++ b/fakeredis/_msgs.py
@@ -54,6 +54,10 @@ DRAGONFLY_LIMIT_NEGATIVE_MSG = "ERR limit can't be negative"
 DRAGONFLY_LIMIT_NOT_POSITIVE_MSG = "ERR limit value is not a positive integer"
 DRAGONFLY_AT_LEAST_ONE_KEY_MSG = "ERR at least 1 input key is needed for this command"
 EXECABORT_MSG = "EXECABORT Transaction discarded because of previous errors."
+# Dragonfly leaves off the full stop, refuses WATCH/SUBSCRIBE inside MULTI by name, and
+# ends the transaction as soon as a command fails to queue.
+DRAGONFLY_EXECABORT_MSG = "EXECABORT Transaction discarded because of previous errors"
+DRAGONFLY_NOT_IN_TRANSACTION_MSG = "ERR '{0}' not allowed inside a transaction"
 MULTI_NESTED_MSG = "ERR MULTI calls can not be nested"
 WITHOUT_MULTI_MSG = "ERR {0} without MULTI"
 WATCH_INSIDE_MULTI_MSG = "ERR WATCH inside MULTI is not allowed"

--- a/fakeredis/commands_mixins/bitmap_mixin.py
+++ b/fakeredis/commands_mixins/bitmap_mixin.py
@@ -172,7 +172,13 @@ class BitmapCommandsMixin(CommandsMixinBase):
         old_value = value if old_byte == new_byte else 1 - value
         reconstructed = bytearray(val)
         reconstructed[byte] = new_byte
-        if bytes(reconstructed) != key.value or (self.version == (6,) and old_byte != new_byte):
+        # Dragonfly dirties the key for any SETBIT, so a no-op still invalidates a WATCH,
+        # whereas redis only does so when the stored value actually changes.
+        if (
+            bytes(reconstructed) != key.value
+            or (self.version == (6,) and old_byte != new_byte)
+            or self._server.server_type == "dragonfly"
+        ):
             key.update(bytes(reconstructed))
         return old_value
 

--- a/fakeredis/commands_mixins/transactions_mixin.py
+++ b/fakeredis/commands_mixins/transactions_mixin.py
@@ -17,6 +17,9 @@ class TransactionsCommandsMixin(CommandsMixinBase):
         # When in a MULTI, set to a list of function calls
         self._transaction: list[Any] | None = None
         self._transaction_failed = False
+        # Dragonfly only: queueing stopped after a command failed to queue, but the queue
+        # itself is kept until the next MULTI resumes it (or DISCARD/EXEC throws it away).
+        self._transaction_paused = False
         # Set when executing the commands from EXEC
         self._in_transaction = False
         self._watch_notified = False
@@ -27,27 +30,61 @@ class TransactionsCommandsMixin(CommandsMixinBase):
             (key, db) = self._watches.pop()
             db.remove_watch(key, self)
 
+    def _forget_watches_without_multi(self) -> None:
+        """Drop the watches a DISCARD/EXEC outside a MULTI clears on dragonfly.
+
+        Redis leaves them armed and answers the error alone.
+        """
+        if self.server_type == "dragonfly":
+            self._clear_watches()
+
+    @property
+    def _queueing(self) -> bool:
+        """Whether a command sent now would be queued rather than run."""
+        return self._transaction is not None and not self._transaction_paused
+
+    def abort_transaction(self) -> None:
+        """Stop queueing the way dragonfly does when a command fails to queue.
+
+        Later commands run immediately and DISCARD reports there is no MULTI, but the queue
+        built so far is kept: the next MULTI picks it up again, and only DISCARD or the
+        EXEC that reports the failure throws it away.
+        """
+        self._transaction_paused = True
+        self._transaction_failed = True
+
+    def _forget_transaction(self) -> None:
+        self._transaction = None
+        self._transaction_paused = False
+        self._transaction_failed = False
+
     # Transaction commands
     @command((), flags=[msgs.FLAG_NO_SCRIPT, msgs.FLAG_TRANSACTION])
     def discard(self) -> SimpleString:
-        if self._transaction is None:
+        if not self._queueing:
+            # A transaction dragonfly stopped queueing is thrown away here, unreported.
+            self._forget_transaction()
+            self._forget_watches_without_multi()
             raise SimpleError(msgs.WITHOUT_MULTI_MSG.format("DISCARD"))
-        self._transaction = None
-        self._transaction_failed = False
+        self._forget_transaction()
         self._clear_watches()
         return OK
 
     @command(name="exec", fixed=(), repeat=(), flags=[msgs.FLAG_NO_SCRIPT, msgs.FLAG_TRANSACTION])
     def exec_(self) -> Any:
-        if self._transaction is None:
+        if not self._queueing:
+            if self._transaction_failed:  # a transaction dragonfly stopped queueing
+                self._forget_transaction()
+                self._clear_watches()
+                raise SimpleError(msgs.DRAGONFLY_EXECABORT_MSG)
+            self._forget_watches_without_multi()
             raise SimpleError(msgs.WITHOUT_MULTI_MSG.format("EXEC"))
         if self._transaction_failed:
-            self._transaction = None
+            self._forget_transaction()
             self._clear_watches()
-            raise SimpleError(msgs.EXECABORT_MSG)
-        transaction = self._transaction
-        self._transaction = None
-        self._transaction_failed = False
+            raise SimpleError(msgs.DRAGONFLY_EXECABORT_MSG if self.server_type == "dragonfly" else msgs.EXECABORT_MSG)
+        transaction = self._transaction or []
+        self._forget_transaction()
         watch_notified = self._watch_notified
         self._clear_watches()
         if watch_notified:
@@ -66,9 +103,13 @@ class TransactionsCommandsMixin(CommandsMixinBase):
 
     @command((), flags=[msgs.FLAG_NO_SCRIPT, msgs.FLAG_TRANSACTION])
     def multi(self) -> SimpleString:
-        if self._transaction is not None:
+        if self._queueing:
             raise SimpleError(msgs.MULTI_NESTED_MSG)
-        self._transaction = []
+        if self._transaction_paused:
+            # Dragonfly picks the kept queue back up rather than starting a new one.
+            self._transaction_paused = False
+        else:
+            self._transaction = []
         self._transaction_failed = False
         return OK
 
@@ -79,7 +120,10 @@ class TransactionsCommandsMixin(CommandsMixinBase):
 
     @command((Key(),), (Key(),), flags=[msgs.FLAG_NO_SCRIPT, msgs.FLAG_TRANSACTION])
     def watch(self, *keys: CommandItem) -> SimpleString:
-        if self._transaction is not None:
+        if self._queueing:
+            if self.server_type == "dragonfly":
+                self.abort_transaction()
+                raise SimpleError(msgs.DRAGONFLY_NOT_IN_TRANSACTION_MSG.format("WATCH"))
             raise SimpleError(msgs.WATCH_INSIDE_MULTI_MSG)
         for key in keys:
             if key not in self._watches:

--- a/fakeredis/model/__init__.py
+++ b/fakeredis/model/__init__.py
@@ -7,6 +7,7 @@ from ._command_info import (
     get_categories,
     get_command_info,
     get_commands_by_category,
+    is_write_command,
 )
 from ._expiring_members_set import ExpiringMembersSet
 from ._hash import Hash
@@ -37,6 +38,7 @@ __all__ = [
     "get_categories",
     "get_command_info",
     "get_commands_by_category",
+    "is_write_command",
 ]
 
 try:

--- a/fakeredis/model/_command_info.py
+++ b/fakeredis/model/_command_info.py
@@ -38,6 +38,12 @@ def get_command_info(cmd: bytes) -> list[Any] | None:
     return _COMMAND_INFO.get(cmd, None)
 
 
+def is_write_command(cmd: bytes) -> bool:
+    """Whether the command is flagged as writing to its keys."""
+    info = get_command_info(cmd)
+    return info is not None and b"write" in info[2]
+
+
 def get_categories() -> list[bytes]:
     _load_command_info()
     if _COMMAND_INFO is None:

--- a/test/test_dragonfly/test_dragonfly_divergences.py
+++ b/test/test_dragonfly/test_dragonfly_divergences.py
@@ -11,6 +11,7 @@ import time
 import uuid
 
 import pytest
+import redis
 
 from fakeredis._typing import ClientType
 from test import testtools
@@ -31,6 +32,12 @@ def _raises(r: ClientType, match: str, *args):
         raw_command(r, *args)
     assert type(ctx.value).__module__ + "." + type(ctx.value).__qualname__ in RESPONSE_ERRORS
     return ctx.value
+
+
+def _raises_execabort(r: ClientType):
+    """EXEC of a transaction dragonfly gave up on; redis-py has its own error for EXECABORT."""
+    with pytest.raises(redis.exceptions.ExecAbortError, match="Transaction discarded because of previous errors"):
+        raw_command(r, "exec")
 
 
 def test_unknown_command_message_format(r: ClientType):
@@ -123,6 +130,41 @@ def test_sort_leaves_equal_weights_in_place(r: ClientType):
     for element in ("zebra", "apple", "mango"):
         r.set(f"w_{element}", "5")
     assert r.sort("l", by="w_*") == [b"zebra", b"apple", b"mango"]
+
+
+@pytest.mark.parametrize(
+    "setup,unchanging_write",
+    [
+        (("set", "foo", b"0"), ("setbit", "foo", 0, 0)),
+        (("set", "foo", b"bar"), ("set", "foo", b"other", "nx")),
+        (("set", "foo", b"bar"), ("persist", "foo")),
+        (("sadd", "foo", "member"), ("srem", "foo", "absent")),
+        (("zadd", "foo", 1.0, "member"), ("zadd", "foo", "nx", 2.0, "member")),
+        (("hset", "foo", "field", "v"), ("hdel", "foo", "absent")),
+    ],
+)
+def test_a_write_dirties_a_watched_key_even_when_it_changes_nothing(r: ClientType, setup, unchanging_write):
+    # Redis only invalidates the watch when the stored value actually changes.
+    raw_command(r, *setup)
+    with r.pipeline() as p:
+        p.watch("foo")
+        raw_command(r, *unchanging_write)
+        p.multi()
+        with pytest.raises(redis.WatchError):
+            p.execute()
+
+
+def test_a_write_leaves_a_watched_key_it_only_reads_alone(r: ClientType):
+    r.sadd("foo", "member")
+    with r.pipeline() as p:
+        p.watch("foo")
+        # SDIFFSTORE only reads the keys after its destination, and a rejected MSETNX
+        # never touches one at all.
+        assert raw_command(r, "sdiffstore", "dst", "foo", "other") == 1
+        assert raw_command(r, "msetnx", "foo", "x") == 0
+        p.multi()
+        p.dbsize()
+        assert p.execute() == [2]  # the watch survived, so the transaction ran
 
 
 def test_sunsubscribe_is_confirmed_as_unsubscribe(r: ClientType):
@@ -286,3 +328,80 @@ def test_a_string_is_capped_at_256mb(r: ClientType):
     # The same cap bounds SETBIT's offset.
     _raises(r, "bit offset is not an integer or out of range", "setbit", "foo", 8 * max_size, 1)
     assert raw_command(r, "setbit", "foo", 8 * max_size - 1, 1) == 0
+
+
+def test_watch_inside_multi_ends_the_transaction(r: ClientType):
+    assert raw_command(r, "multi") == b"OK"
+    _raises(r, "'WATCH' not allowed inside a transaction", "watch", "foo")
+    # The queue is gone: commands run immediately and DISCARD reports there is no MULTI.
+    assert raw_command(r, "set", "foo", "bar") == b"OK"
+    assert r.get("foo") == b"bar"
+    _raises(r, "DISCARD without MULTI", "discard")
+    # ...and DISCARD is the end of it, so EXEC no longer remembers the failure.
+    _raises(r, "EXEC without MULTI", "exec")
+
+
+def test_exec_after_an_aborted_transaction_reports_execabort(r: ClientType):
+    assert raw_command(r, "multi") == b"OK"
+    _raises(r, "'WATCH' not allowed inside a transaction", "watch", "foo")
+    _raises_execabort(r)
+    _raises(r, "EXEC without MULTI", "exec")
+
+
+def test_a_command_that_cannot_be_queued_ends_the_transaction(r: ClientType):
+    assert raw_command(r, "multi") == b"OK"
+    _raises(r, "wrong number of arguments", "get")
+    # Redis would queue this and refuse the EXEC; dragonfly has already run it.
+    assert raw_command(r, "set", "foo", "bar") == b"OK"
+    assert r.get("foo") == b"bar"
+    _raises_execabort(r)
+
+
+def test_an_unknown_command_leaves_the_transaction_alone(r: ClientType):
+    assert raw_command(r, "multi") == b"OK"
+    _raises(r, "unknown command", "nosuchcmd")
+    assert raw_command(r, "set", "foo", "bar") == b"QUEUED"
+    assert raw_command(r, "exec") == [b"OK"]
+    assert r.get("foo") == b"bar"
+
+
+@pytest.mark.parametrize("subscribe_command", ["subscribe", "psubscribe", "ssubscribe"])
+def test_subscribing_is_not_allowed_inside_a_transaction(r: ClientType, subscribe_command: str):
+    # Redis queues these and runs them at EXEC; dragonfly refuses them outright.
+    assert raw_command(r, "multi") == b"OK"
+    _raises(r, f"'{subscribe_command.upper()}' not allowed inside a transaction", subscribe_command, "chan")
+    _raises_execabort(r)
+
+
+def test_a_stopped_transaction_keeps_its_queue_for_the_next_multi(r: ClientType):
+    # Redis would have queued the WATCH's neighbours and refused the EXEC; dragonfly stops
+    # queueing but hangs on to what it has, and the next MULTI carries on where it left off.
+    assert raw_command(r, "multi") == b"OK"
+    assert raw_command(r, "set", "first", "1") == b"QUEUED"
+    _raises(r, "'WATCH' not allowed inside a transaction", "watch", "foo")
+    assert raw_command(r, "multi") == b"OK"
+    assert raw_command(r, "set", "second", "2") == b"QUEUED"
+    assert raw_command(r, "exec") == [b"OK", b"OK"]
+    assert r.mget("first", "second") == [b"1", b"2"]
+
+
+def test_discard_throws_the_kept_queue_away(r: ClientType):
+    assert raw_command(r, "multi") == b"OK"
+    assert raw_command(r, "set", "first", "1") == b"QUEUED"
+    _raises(r, "'WATCH' not allowed inside a transaction", "watch", "foo")
+    _raises(r, "DISCARD without MULTI", "discard")
+    assert raw_command(r, "multi") == b"OK"
+    assert raw_command(r, "exec") == []
+    assert r.exists("first") == 0
+
+
+def test_a_discard_without_multi_still_clears_the_watches(r: ClientType):
+    # Redis leaves the watch armed and answers the error alone, so its EXEC would abort.
+    for failing_command in ("discard", "exec"):
+        r.delete("foo")
+        assert raw_command(r, "watch", "foo") == b"OK"
+        _raises(r, f"{failing_command.upper()} without MULTI", failing_command)
+        r.set("foo", "bar")  # would break the watch
+        assert raw_command(r, "multi") == b"OK"
+        assert raw_command(r, "get", "foo") == b"QUEUED"
+        assert raw_command(r, "exec") == [b"bar"]

--- a/test/test_mixins/test_generic_commands.py
+++ b/test/test_mixins/test_generic_commands.py
@@ -765,14 +765,20 @@ def test_key_patterns(r: ClientType):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
-def test_watch_when_setbit_does_not_change_value(r: ClientType):
+def test_watch_when_setbit_does_not_change_value(r: ClientType, real_server_details):
     r.set("foo", b"0")
 
     with r.pipeline() as p:
         p.watch("foo")
         assert r.setbit("foo", 0, 0) == 0
         assert p.multi() is None
-        assert p.execute() == []
+        if real_server_details.server_type == "dragonfly":
+            # Dragonfly dirties a watched key on any SETBIT, even one that writes back
+            # the value it already held.
+            with pytest.raises((redis.WatchError, valkey.WatchError)):
+                p.execute()
+        else:
+            assert p.execute() == []
 
 
 def test_from_hypothesis_redis7(r: ClientType):


### PR DESCRIPTION
Two transaction-shaped divergences, both of which change what a client sees
rather than only how an error is worded.

**WATCH invalidation.** Dragonfly dirties every key a write command runs
against, whether or not the write changed anything. A rejected `SET NX`, a
`SREM` that removed nothing, a `SETBIT` that wrote back the byte it already
held -- each breaks a WATCH on the key, where Redis only invalidates when the
stored value actually changes. Two groups of commands are exempt: the ones that
merely read the keys beside their destination (SINTERSTORE, SORT, BITOP, ...),
and the two that bow out before touching the key at all -- a rejected MSETNX and
a SETRANGE with an empty value. A key that does not exist stays clean either
way.

**Queueing.** Redis queues on after a command fails to queue and refuses the
EXEC; Dragonfly stops queueing there and then. Later commands run immediately
and DISCARD reports there is no MULTI -- but the queue built so far is *kept*,
and the next MULTI picks it back up rather than starting a new one. Only DISCARD
or the EXEC that reports the failure throws it away. That state is a third one
beyond "in a MULTI" and "not in a MULTI", so `_transaction_paused` joins
`_transaction`, with a `_queueing` property naming the combination the dispatch
loop actually cares about.

Around that:

* An unknown command is the one failure that leaves the transaction unharmed.
* WATCH and the (un)subscribe family are refused inside a MULTI by name --
  "'WATCH' not allowed inside a transaction" -- and WATCH's refusal also ends
  the queueing.
* EXECABORT drops Redis' trailing full stop.
* A DISCARD or EXEC issued outside a MULTI clears the armed watches, where Redis
  leaves them alone and answers the error only.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!--STACK-->
### This PR is part of a stack

`#373` split into twelve reviewable pieces. Each branches off the one above it, so they
merge in order; the diff shown here is only this step's own changes.

**#553 and #554 are merged.** #554 went into `df/01-prep` first, so master's squash commit
`b22d569e` carries both; the rest of the stack has been rebased onto master accordingly.

| PR | Branch | What it covers |
|---|--------|----------------|
| ~~#553~~ ✅ | `df/01-prep` | Server-agnostic fixes: SMOVE, BITCOUNT, GEO ordering, shared zset reply shaping |
| ~~#554~~ ✅ | `df/02-harness` | Build `FakeServer` with the Redis version Dragonfly reports; TCP server + CI plumbing |
| #555 | `df/03-errors` | Error wording and argument validation |
| #556 | `df/04-limits` | Expiry horizon, hash-field TTL cap, 256MB value cap |
| #557 | `df/05-reply-shapes` | Doubles, timed-out blocking pops, sorted-set reply shapes |
| #558 | `df/06-streams` | XREAD/XREADGROUP/XINFO/XPENDING replies |
| #559 | `df/07-pubsub` | Shard and plain channels in one namespace |
| #560 | `df/08-sort-copy-geo` | SORT patterns, COPY without DB, GEO ordering |
| #561 | `df/09-transactions` | WATCH invalidation and MULTI queueing |
| #562 | `df/10-scripting` | Lua 5.4 semantics and script error wording |
| #563 | `df/11-json` | Dragonfly's own JSON implementation |
| #564 | `df/12-hypothesis-docs` | Hypothesis guards + `docs/dragonfly-support.md` |

Verified against a real Dragonfly (`df-v1.40.1`) and a real Redis (`8.4.0`, all modules loaded): every
branch in the stack has an identical failure set to `master`, and the tip of the stack has two
*fewer* failures than `master` (PR #559 repairs a pre-existing pub/sub subscription leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
