### PR TITLE
feat(dragonfly): emulate its Lua scripting divergences

### DIFF
--- a/fakeredis/_basefakesocket.py
+++ b/fakeredis/_basefakesocket.py
@@ -31,6 +31,11 @@ from ._typing import ResponseErrorType, ServerType, VersionType
 
 LOGGER = logging.getLogger("fakeredis")
 
+
+# Commands Dragonfly refuses to run from inside a Lua script but Redis is happy to run.
+# The rest of Dragonfly's no-script set (SAVE, BGSAVE, SCRIPT, EVAL, MULTI/EXEC, the
+# (P)SUBSCRIBE family and the blocking pops) already carries `FLAG_NO_SCRIPT` here.
+DRAGONFLY_NO_SCRIPT_COMMANDS = frozenset({"flushdb", "flushall", "shutdown", "debug", "config", "client"})
 # Dragonfly refuses to queue the (un)subscribe family inside a MULTI, where redis queues it.
 DRAGONFLY_NO_TRANSACTION_COMMANDS = frozenset(
     {"subscribe", "unsubscribe", "psubscribe", "punsubscribe", "ssubscribe", "sunsubscribe"}
@@ -379,8 +384,10 @@ class BaseFakeSocket:
         is_dragonfly = self.server_type == "dragonfly"
         try:
             ret = sig.apply(args, self._db, self.version)
-            if from_script and msgs.FLAG_NO_SCRIPT in sig.flags:
-                raise SimpleError(msgs.COMMAND_IN_SCRIPT_MSG)
+            if from_script and (
+                msgs.FLAG_NO_SCRIPT in sig.flags or (is_dragonfly and sig.name in DRAGONFLY_NO_SCRIPT_COMMANDS)
+            ):
+                raise SimpleError(msgs.DRAGONFLY_COMMAND_IN_SCRIPT_MSG if is_dragonfly else msgs.COMMAND_IN_SCRIPT_MSG)
             if self._pubsub and sig.name not in BaseFakeSocket.ACCEPTED_COMMANDS_WHILE_PUBSUB:
                 raise SimpleError(msgs.BAD_COMMAND_IN_PUBSUB_MSG)
             if len(ret) == 1:
@@ -389,7 +396,13 @@ class BaseFakeSocket:
                 args, command_items = ret
                 result = func(*args)  # type: ignore
                 if self._client_info.protocol_version == 2 and msgs.FLAG_SKIP_CONVERT_TO_RESP2 not in sig.flags:
-                    result = _convert_to_resp2(result, self.server_type)
+                    result = _convert_to_resp2(
+                        result,
+                        self.server_type,
+                        # Dragonfly gives a script's `redis.call` a double as a Lua number
+                        # whatever protocol the client that invoked the script speaks.
+                        keep_doubles=from_script and is_dragonfly,
+                    )
                 if msgs.FLAG_SKIP_CONVERT_TO_RESP2 not in sig.flags and not valid_response_type(
                     result, self._client_info.protocol_version
                 ):

--- a/fakeredis/_msgs.py
+++ b/fakeredis/_msgs.py
@@ -78,6 +78,7 @@ UNBLOCKED_MSG = "UNBLOCKED client unblocked via CLIENT UNBLOCK"
 NO_MATCHING_SCRIPT_MSG = "NOSCRIPT No matching script. Please use EVAL."
 GLOBAL_VARIABLE_MSG = "ERR Script attempted to set global variables: {}"
 COMMAND_IN_SCRIPT_MSG = "ERR This Redis command is not allowed from scripts"
+DRAGONFLY_COMMAND_IN_SCRIPT_MSG = "ERR This Redis command is not allowed from script"
 BAD_SUBCOMMAND_MSG = "ERR Unknown {} subcommand or wrong # of args."
 BAD_COMMAND_IN_PUBSUB_MSG = "ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context"
 CONNECTION_ERROR_MSG = "FakeRedis is emulating a connection error."
@@ -88,6 +89,9 @@ LUA_COMMAND_ARG_MSG = "ERR Lua redis lib command arguments must be strings or in
 VALKEY_LUA_COMMAND_ARG_MSG = "Command arguments must be strings or integers script: {}"
 LUA_WRONG_NUMBER_ARGS_MSG = "ERR wrong number or type of arguments"
 SCRIPT_ERROR_MSG = "ERR Error running script (call to f_{}): @user_script:?: {}"
+# Dragonfly reports redis_version 7.x but still wraps script errors the way Redis 6 did,
+# minus the `f_` prefix on the sha.
+DRAGONFLY_SCRIPT_ERROR_MSG = "ERR Error running script (call to {}): @user_script:?: {}"
 RESTORE_KEY_EXISTS = "BUSYKEY Target key name already exists."
 RESTORE_INVALID_CHECKSUM_MSG = "ERR DUMP payload version or checksum are wrong"
 

--- a/fakeredis/commands_mixins/scripting_mixin.py
+++ b/fakeredis/commands_mixins/scripting_mixin.py
@@ -52,6 +52,33 @@ REDIS_LOG_LEVELS_TO_LOGGING = {
 
 _lua_cjson_null = object()  # sentinel value
 
+# Dragonfly's own SCRIPT HELP text, reproduced verbatim -- including the trailing space on
+# the "following flags" line and the "sript" typo.
+DRAGONFLY_SCRIPT_HELP = [
+    "SCRIPT <subcommand> [<arg> [value] [opt] ...]",
+    "Subcommands are:",
+    "EXISTS <sha1> [<sha1> ...]",
+    "   Return information about the existence of the scripts in the script cache.",
+    "FLUSH",
+    "   Flush the Lua scripts cache. Very dangerous on replicas.",
+    "LOAD <script>",
+    "   Load a script into the scripts cache without executing it.",
+    "FLAGS <sha> [flags ...]",
+    "   Set specific flags for script. Can be called before the sript is loaded.",
+    "   The following flags are possible: ",
+    "      - Use 'allow-undeclared-keys' to allow accessing undeclared keys",
+    "      - Use 'disable-atomicity' to allow running scripts non-atomically",
+    "      - Use 'legacy-float' to return floats as integers",
+    "LIST",
+    "   Lists loaded scripts.",
+    "LATENCY",
+    "   Prints latency histograms in usec for every called function.",
+    "GC",
+    "   Invokes garbage collection on all unused interpreter instances.",
+    "HELP",
+    "   Prints this help.",
+]
+
 
 class ScriptingCommandsMixin(CommandsMixinBase):
     _name_to_func: Callable[[str], tuple[Callable[..., Any] | None, Signature]]
@@ -65,6 +92,10 @@ class ScriptingCommandsMixin(CommandsMixinBase):
         if isinstance(result, (bytes, int)):
             return result
         if isinstance(result, float):
+            # Redis hands a double reply (ZSCORE, INCRBYFLOAT, ...) to Lua as a string;
+            # Dragonfly hands it over as a number.
+            if self.server_type == "dragonfly":
+                return result
             return Float.encode(result, humanfriendly=False)
         elif isinstance(result, SimpleString):
             return lua_runtime.table_from({b"ok": result.value})
@@ -108,6 +139,12 @@ class ScriptingCommandsMixin(CommandsMixinBase):
         elif isinstance(result, str):
             return result.encode()
         elif isinstance(result, float):
+            # Redis truncates every Lua number to an integer. Dragonfly, whose interpreter
+            # is Lua 5.4, keeps a non-integral one and replies with a double. It tells 3
+            # from 3.0 through Lua 5.4's integer subtype, which the 5.1 runtime used here
+            # does not have, so a whole number is returned as an integer either way.
+            if self.server_type == "dragonfly" and not result.is_integer():
+                return result
             return int(result)
         elif isinstance(result, bool):
             return 1 if result else None
@@ -220,7 +257,7 @@ class ScriptingCommandsMixin(CommandsMixinBase):
             # Cache the callback wrappers and static partials
             s._lua_redis_call_wrapper = make_redis_call_wrapper()
             s._lua_redis_pcall_wrapper = make_redis_pcall_wrapper()
-            s._lua_log_partial = functools.partial(_lua_redis_log, lua_runtime, expected_globals)
+            s._lua_log_partial = functools.partial(_lua_redis_log, lua_runtime, expected_globals, server.server_type)
             s._lua_cjson_encode_partial = functools.partial(_lua_cjson_encode, lua_runtime, expected_globals)
             s._lua_cjson_decode_partial = functools.partial(_lua_cjson_decode, lua_runtime, expected_globals)
 
@@ -261,12 +298,17 @@ class ScriptingCommandsMixin(CommandsMixinBase):
         try:
             result = lua_runtime.execute(script)
         except SimpleError as ex:
-            if ex.value == msgs.LUA_COMMAND_ARG_MSG:
-                raise SimpleError(_get_lua_bad_command_arg_msg(self._server.server_type, self.version))
-            if self.version < (7,):
-                raise SimpleError(msgs.SCRIPT_ERROR_MSG.format(sha1.decode(), ex))
-            raise SimpleError(ex.value)
+            error_msg = ex.value
+            if error_msg == msgs.LUA_COMMAND_ARG_MSG:
+                error_msg = _get_lua_bad_command_arg_msg(self._server.server_type, self.version)
+            elif self.version < (7,):
+                error_msg = msgs.SCRIPT_ERROR_MSG.format(sha1.decode(), error_msg)
+            if self.server_type == "dragonfly":
+                error_msg = msgs.DRAGONFLY_SCRIPT_ERROR_MSG.format(sha1.decode(), error_msg)
+            raise SimpleError(error_msg)
         except LUA_MODULE.LuaError as ex:
+            if self.server_type == "dragonfly":
+                raise SimpleError(msgs.DRAGONFLY_SCRIPT_ERROR_MSG.format(sha1.decode(), ex))
             raise SimpleError(msgs.SCRIPT_ERROR_MSG.format(sha1.decode(), ex))
         finally:
             # Clean up Lua tables (KEYS/ARGV) created for this script execution
@@ -301,7 +343,10 @@ class ScriptingCommandsMixin(CommandsMixinBase):
 
     @command(name="SCRIPT FLUSH", fixed=(), repeat=(bytes,), flags=msgs.FLAG_NO_SCRIPT)
     def script_flush(self, *args: bytes) -> SimpleString:
-        if len(args) > 1 or (len(args) == 1 and null_terminate(args[0]) not in {b"sync", b"async"}):
+        # Dragonfly has no ASYNC/SYNC mode for SCRIPT FLUSH and ignores whatever follows.
+        if self.server_type != "dragonfly" and (
+            len(args) > 1 or (len(args) == 1 and null_terminate(args[0]) not in {b"sync", b"async"})
+        ):
             raise SimpleError(msgs.BAD_SUBCOMMAND_MSG.format("SCRIPT"))
         self._server.script_cache = {}
         return OK
@@ -312,6 +357,8 @@ class ScriptingCommandsMixin(CommandsMixinBase):
 
     @command(name="SCRIPT HELP", fixed=())
     def script_help(self, *args: bytes) -> list[bytes]:
+        if self.server_type == "dragonfly":
+            return [s.encode() for s in DRAGONFLY_SCRIPT_HELP]
         help_strings = [
             "SCRIPT <subcommand> [<arg> [value] [opt] ...]. Subcommands are:",
             "DEBUG (YES|SYNC|NO)",
@@ -360,11 +407,14 @@ def _check_for_lua_globals(lua_runtime: Any, expected_globals: set[Any]) -> None
         raise SimpleError(msgs.GLOBAL_VARIABLE_MSG.format(", ".join(unexpected)))
 
 
-def _lua_redis_log(lua_runtime: Any, expected_globals: set[Any], lvl: int, *args: Any) -> None:
+def _lua_redis_log(lua_runtime: Any, expected_globals: set[Any], server_type: ServerType, lvl: int, *args: Any) -> None:
     _check_for_lua_globals(lua_runtime, expected_globals)
     if len(args) < 1:
         raise SimpleError(msgs.REQUIRES_MORE_ARGS_MSG.format("redis.log()", "two"))
     if lvl not in REDIS_LOG_LEVELS_TO_LOGGING:
+        # Dragonfly accepts any level and drops the message rather than erroring.
+        if server_type == "dragonfly":
+            return
         raise SimpleError(msgs.LOG_INVALID_DEBUG_LEVEL_MSG)
     msg = " ".join([x.decode("utf-8") if isinstance(x, bytes) else str(x) for x in args if not isinstance(x, bool)])
     LOGGER.log(REDIS_LOG_LEVELS_TO_LOGGING[lvl], msg)
@@ -425,6 +475,7 @@ def _lua_cjson_decode(lua_runtime: Any, expected_globals: set[Any], json_str: st
 def _get_lua_bad_command_arg_msg(server_type: ServerType, server_version: VersionType) -> str:
     if server_type == "valkey":
         return msgs.VALKEY_LUA_COMMAND_ARG_MSG
-    if server_version < (7,):
+    # Dragonfly kept the pre-7 wording, which names `redis()` rather than "redis lib".
+    if server_type == "dragonfly" or server_version < (7,):
         return msgs.LUA_COMMAND_ARG_MSG6
     return msgs.LUA_COMMAND_ARG_MSG

--- a/test/test_dragonfly/test_scripting_dragonfly.py
+++ b/test/test_dragonfly/test_scripting_dragonfly.py
@@ -1,0 +1,127 @@
+"""Lua scripting behaviour where Dragonfly deliberately differs from Redis.
+
+The Redis-flavoured versions of these tests live in
+`test/test_mixins/test_scripting_commands.py` and are marked
+`@pytest.mark.unsupported_server_types("dragonfly")`; these are the Dragonfly
+counterparts, so both sides of each divergence stay covered.
+"""
+
+from __future__ import annotations
+
+import pytest
+import redis
+import valkey
+
+from fakeredis._typing import ClientType
+from test.testtools import raw_command, resp_conversion
+
+_ = pytest.importorskip("lupa")
+
+pytestmark = []
+pytestmark.extend(
+    [
+        pytest.mark.unsupported_server_types("redis", "valkey"),
+    ]
+)
+
+
+@pytest.mark.parametrize("args", [("a",), tuple("abcdefghijklmn")])
+def test_script_flush_ignores_extra_args(r: ClientType, args: tuple[str, ...]):
+    # Redis rejects anything that is not ASYNC/SYNC; Dragonfly has no mode argument at all
+    # and simply ignores whatever follows.
+    sha1 = r.script_load("return 'a'")
+    assert raw_command(r, "SCRIPT FLUSH {}".format(" ".join(args))) == b"OK"
+    assert r.script_exists(sha1) == [0]
+
+
+def test_script_help(r: ClientType):
+    assert raw_command(r, "SCRIPT HELP") == [
+        b"SCRIPT <subcommand> [<arg> [value] [opt] ...]",
+        b"Subcommands are:",
+        b"EXISTS <sha1> [<sha1> ...]",
+        b"   Return information about the existence of the scripts in the script cache.",
+        b"FLUSH",
+        b"   Flush the Lua scripts cache. Very dangerous on replicas.",
+        b"LOAD <script>",
+        b"   Load a script into the scripts cache without executing it.",
+        b"FLAGS <sha> [flags ...]",
+        b"   Set specific flags for script. Can be called before the sript is loaded.",
+        b"   The following flags are possible: ",
+        b"      - Use 'allow-undeclared-keys' to allow accessing undeclared keys",
+        b"      - Use 'disable-atomicity' to allow running scripts non-atomically",
+        b"      - Use 'legacy-float' to return floats as integers",
+        b"LIST",
+        b"   Lists loaded scripts.",
+        b"LATENCY",
+        b"   Prints latency histograms in usec for every called function.",
+        b"GC",
+        b"   Invokes garbage collection on all unused interpreter instances.",
+        b"HELP",
+        b"   Prints this help.",
+    ]
+
+
+@pytest.mark.parametrize("value", [3.2, 3.8, -3.8])
+def test_eval_keeps_fractional_numbers(r: ClientType, value: float):
+    # Redis truncates every Lua number to an integer, Dragonfly replies with a double --
+    # rendered under RESP2 as the shortest bulk string that round-trips.
+    assert r.eval(f"return {value}", 0) == resp_conversion(r, value, str(value).encode())
+
+
+def test_eval_still_truncates_whole_numbers(r: ClientType):
+    # `return 3.0` is not asserted here: Dragonfly runs Lua 5.4, whose integer subtype tells
+    # it apart from `return 3` and makes it a double, and the 5.1 runtime fakeredis uses
+    # cannot draw that distinction.
+    assert r.eval("return 3", 0) == 3
+
+
+def test_eval_call_bool(r: ClientType):
+    # Dragonfly kept the pre-7 wording, which names `redis()` rather than "redis lib".
+    with pytest.raises(Exception) as exc_info:
+        r.eval('return redis.call("SET", KEYS[1], true)', 1, "testkey")
+    assert isinstance(exc_info.value, (redis.ResponseError, valkey.ResponseError))
+    assert "Lua redis() command arguments must be strings or integers" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("command", ["FLUSHDB", "FLUSHALL"])
+def test_eval_cannot_flush(r: ClientType, command: str):
+    # Redis lets a script flush the keyspace; Dragonfly refuses.
+    r.set("foo", "bar")
+    with pytest.raises(Exception, match="not allowed from script") as exc_info:
+        r.eval(f'return redis.call("{command}")', 0)
+    assert isinstance(exc_info.value, (redis.ResponseError, valkey.ResponseError))
+    assert r.get("foo") == b"bar"
+
+
+def test_eval_incrbyfloat_returns_a_number(r: ClientType):
+    # Redis hands INCRBYFLOAT's bulk string to Lua as a string, Dragonfly as a number.
+    r.set("foo", 0.5)
+    val = r.eval(
+        """
+        local value = redis.call("INCRBYFLOAT", KEYS[1], 2.0);
+        return type(value) == "number" and tostring(value) or type(value);
+        """,
+        1,
+        "foo",
+    )
+    assert val == b"2.5"
+
+
+def test_incrbyfloat_replies_with_a_double(r: ClientType):
+    r.set("foo", 0.5)
+    assert raw_command(r, "INCRBYFLOAT", "foo", "2.0") == resp_conversion(r, 2.5, b"2.5")
+
+
+def test_hincrbyfloat_replies_with_a_double(r: ClientType):
+    assert raw_command(r, "HINCRBYFLOAT", "foo", "field", "1.5") == resp_conversion(r, 1.5, b"1.5")
+
+
+def test_lua_log_ignores_wrong_level(r: ClientType):
+    # Redis rejects a level outside LOG_DEBUG..LOG_WARNING; Dragonfly drops the message.
+    assert r.register_script("redis.log(10, 'string')")() is None
+
+
+def test_lua_log_still_needs_two_arguments(r: ClientType):
+    with pytest.raises(Exception, match="requires two arguments or more") as ctx:
+        r.register_script("redis.log(redis.LOG_WARNING)")()
+    assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))

--- a/test/test_mixins/test_scripting_commands.py
+++ b/test/test_mixins/test_scripting_commands.py
@@ -38,6 +38,7 @@ def test_script_exists_redis7(r: ClientType):
     assert r.script_exists("a", sha1_one, "c", sha1_two, "e", "f") == [0, 1, 0, 1, 0, 0]
 
 
+@pytest.mark.unsupported_server_types("dragonfly")
 @pytest.mark.parametrize("args", [("a",), tuple("abcdefghijklmn")])
 def test_script_flush_errors_with_args(r, args):
     with pytest.raises(Exception) as ctx:
@@ -90,7 +91,7 @@ def test_script_help(r: ClientType):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7.1")
-@pytest.mark.unsupported_server_types("valkey")
+@pytest.mark.unsupported_server_types("valkey", "dragonfly")
 def test_script_help73(r: ClientType):
     assert raw_command(r, "SCRIPT HELP") == [
         b"SCRIPT <subcommand> [<arg> [value] [opt] ...]. Subcommands are:",
@@ -313,6 +314,7 @@ def test_eval_global_and_return_ok(r: ClientType):
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 
 
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_eval_convert_number(r: ClientType):
     # Redis forces all Lua numbers to integer
     val = r.eval("return 3.2", 0)
@@ -332,7 +334,7 @@ def test_eval_convert_bool(r: ClientType):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
-@pytest.mark.unsupported_server_types("valkey")
+@pytest.mark.unsupported_server_types("valkey", "dragonfly")
 def test_eval_call_bool7_redis(r: ClientType):
     # Redis doesn't allow Lua bools to be passed to [p]call
     with pytest.raises(Exception) as exc_info:
@@ -342,7 +344,7 @@ def test_eval_call_bool7_redis(r: ClientType):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
-@pytest.mark.unsupported_server_types("redis")
+@pytest.mark.unsupported_server_types("redis", "dragonfly")
 def test_eval_call_bool7_valkey(r: ClientType):
     # Redis doesn't allow Lua bools to be passed to [p]call
     with pytest.raises(Exception) as exc_info:
@@ -427,6 +429,7 @@ def test_eval_exists(r: ClientType):
     assert val == 1
 
 
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_eval_flushdb(r: ClientType):
     r.set("foo", "bar")
     val = r.eval(
@@ -439,6 +442,7 @@ def test_eval_flushdb(r: ClientType):
     assert val == 1
 
 
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_eval_flushall(r, create_connection):
     r1 = create_connection(db=2)
     r2 = create_connection(db=3)
@@ -459,6 +463,7 @@ def test_eval_flushall(r, create_connection):
     assert "r2" not in r2
 
 
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_eval_incrbyfloat(r: ClientType):
     r.set("foo", 0.5)
     val = r.eval(
@@ -587,6 +592,7 @@ def test_lua_log_different_types(r, caplog):
     assert len(set(caplog.record_tuples).intersection({(logger.name, logging.DEBUG, "string 1 3.14 string")})) == 1
 
 
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_lua_log_wrong_level(r: ClientType):
     script = "redis.log(10, 'string')"
     script = r.register_script(script)


### PR DESCRIPTION
Dragonfly's interpreter is Lua 5.4, not 5.1, and that accounts for most of the
difference:

* Redis truncates every Lua number to an integer on the way out. Dragonfly keeps
  a non-integral one and replies with a double, telling `3` from `3.0` through
  Lua 5.4's integer subtype. The 5.1 runtime used here has no such subtype, so a
  whole number is returned as an integer either way -- which matches, since
  Dragonfly does the same for a genuine integer.
* In the other direction, a double reply (ZSCORE, INCRBYFLOAT, ...) is handed to
  Lua as a *number*, where Redis hands it over as a string. And `redis.call`
  gives a script a double as a Lua number whatever protocol the client that
  invoked the script speaks, so the RESP2 conversion has to be skipped for a
  call made from inside a script.

The rest is Dragonfly's own policy:

* FLUSHDB, FLUSHALL, SHUTDOWN, DEBUG, CONFIG and CLIENT are refused from inside
  a script (the rest of its no-script set already carries `FLAG_NO_SCRIPT`
  here), with "not allowed from script" -- singular.
* Script errors are wrapped the way Redis 6 wrapped them, minus the `f_` prefix
  on the sha, even though Dragonfly reports redis_version 7.x. The bad-command-
  argument message keeps the pre-7 wording too.
* `redis.log` accepts any level and quietly drops the message rather than
  erroring on an unknown one.
* SCRIPT FLUSH has no ASYNC/SYNC mode and ignores whatever follows it, and
  SCRIPT HELP ships Dragonfly's own text -- reproduced verbatim, trailing space
  and "sript" typo included.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!--STACK-->
### This PR is part of a stack

`#373` split into twelve reviewable pieces. Each branches off the one above it, so they
merge in order; the diff shown here is only this step's own changes.

**#553 and #554 are merged.** #554 went into `df/01-prep` first, so master's squash commit
`b22d569e` carries both; the rest of the stack has been rebased onto master accordingly.

| PR | Branch | What it covers |
|---|--------|----------------|
| ~~#553~~ ✅ | `df/01-prep` | Server-agnostic fixes: SMOVE, BITCOUNT, GEO ordering, shared zset reply shaping |
| ~~#554~~ ✅ | `df/02-harness` | Build `FakeServer` with the Redis version Dragonfly reports; TCP server + CI plumbing |
| #555 | `df/03-errors` | Error wording and argument validation |
| #556 | `df/04-limits` | Expiry horizon, hash-field TTL cap, 256MB value cap |
| #557 | `df/05-reply-shapes` | Doubles, timed-out blocking pops, sorted-set reply shapes |
| #558 | `df/06-streams` | XREAD/XREADGROUP/XINFO/XPENDING replies |
| #559 | `df/07-pubsub` | Shard and plain channels in one namespace |
| #560 | `df/08-sort-copy-geo` | SORT patterns, COPY without DB, GEO ordering |
| #561 | `df/09-transactions` | WATCH invalidation and MULTI queueing |
| #562 | `df/10-scripting` | Lua 5.4 semantics and script error wording |
| #563 | `df/11-json` | Dragonfly's own JSON implementation |
| #564 | `df/12-hypothesis-docs` | Hypothesis guards + `docs/dragonfly-support.md` |

Verified against a real Dragonfly (`df-v1.40.1`) and a real Redis (`8.4.0`, all modules loaded): every
branch in the stack has an identical failure set to `master`, and the tip of the stack has two
*fewer* failures than `master` (PR #559 repairs a pre-existing pub/sub subscription leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
