### PR TITLE
feat(dragonfly): emulate its JSON divergences

### DIFF
--- a/fakeredis/stack/_json_mixin.py
+++ b/fakeredis/stack/_json_mixin.py
@@ -19,9 +19,34 @@ from fakeredis import _msgs as msgs
 from fakeredis._command_args_parsing import extract_args
 from fakeredis._commands import CommandItem, Float, Int, Key, command, delete_keys
 from fakeredis._helpers import SimpleString
-from fakeredis._typing import JsonType
+from fakeredis._typing import JsonType, ServerType
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
 from fakeredis.model import ZSet
+
+
+def _key_not_found(server_type: ServerType) -> helpers.SimpleError:
+    """The error a JSON command answers with when the key does not exist.
+
+    Dragonfly reports the plain `no such key`, where RedisJSON spells the operation out.
+    """
+    return helpers.SimpleError(msgs.NO_KEY_MSG if server_type == "dragonfly" else msgs.JSON_KEY_NOT_FOUND)
+
+
+# Marks a JSON.ARRPOP match that is not an array, which the servers report differently from
+# an array with nothing left to pop.
+_NOT_AN_ARRAY = object()
+
+
+def _path_is_legacy(path_str: bytes | str | None) -> bool:
+    """Whether `path_str` is a legacy path (`.a`) rather than a JSONPath (`$.a`).
+
+    An omitted path counts as legacy: the reply is shaped for the single root match.
+    """
+    if path_str is None:
+        return True
+    if isinstance(path_str, str):
+        path_str = path_str.encode()
+    return not path_str.startswith(b"$")
 
 
 def _format_path(path: bytes | str) -> str:
@@ -37,7 +62,11 @@ def _format_path(path: bytes | str) -> str:
 
 
 @lru_cache(maxsize=64)
-def _parse_jsonpath(path: str | bytes) -> JSONPath:
+def _parse_jsonpath(path: str | bytes, server_type: ServerType = "redis") -> JSONPath:
+    if server_type == "dragonfly" and "[?" in (path.decode() if isinstance(path, bytes) else path):
+        # Dragonfly's JSONPath has no filter expressions: `$.a[?(@.b>1)]` is a syntax error,
+        # while wildcards and recursive descent parse as they do on RedisJSON.
+        raise helpers.SimpleError(msgs.SYNTAX_ERROR_MSG)
     path_str: str = _format_path(path)
     try:
         return parse(path_str)
@@ -208,13 +237,14 @@ def _json_write_iterate(
     key: CommandItem,
     path_str: str | bytes,
     allow_result_none: bool = False,
+    server_type: ServerType = "redis",
 ) -> JsonType:
     """Implement json.* write commands.
     Iterate over values with path_str in key and running method to get new value for path item.
     """
     if key.value is None:
-        raise helpers.SimpleError(msgs.JSON_KEY_NOT_FOUND)
-    path = _parse_jsonpath(path_str)
+        raise _key_not_found(server_type)
+    path = _parse_jsonpath(path_str, server_type)
     found_matches = path.find(key.value)
     if len(found_matches) == 0:
         raise helpers.SimpleError(msgs.JSON_PATH_NOT_FOUND_OR_NOT_STRING.format(path_str))
@@ -244,15 +274,16 @@ def _json_read_iterate(
     key: CommandItem,
     *args: Any,
     error_on_zero_matches: bool = False,
+    server_type: ServerType = "redis",
 ) -> list[Any | None] | Any | None:
     path_str = args[0] if len(args) > 0 else "$"
     if key.value is None:
         if path_str[0] == ord(b"$"):
-            raise helpers.SimpleError(msgs.JSON_KEY_NOT_FOUND)
+            raise _key_not_found(server_type)
         else:
             return None
 
-    path = _parse_jsonpath(path_str)
+    path = _parse_jsonpath(path_str, server_type)
     found_matches = path.find(key.value)
     if error_on_zero_matches and len(found_matches) == 0 and path_str[0] != ord(b"$"):
         raise helpers.SimpleError(msgs.JSON_PATH_NOT_FOUND_OR_NOT_STRING.format(path_str))
@@ -292,14 +323,52 @@ class JSONCommandsMixin(CommandsMixinBase):
         super().__init__(*args, **kwargs)
         self._db: helpers.Database
 
-    @staticmethod
+    def _legacy_path_reply(self, res: Any, legacy: bool) -> list[Any | None] | Any | None:
+        """Shape the reply to a legacy path the way the server under test shapes it.
+
+        Under RESP3 dragonfly answers a legacy path with the one-element array it answers a
+        JSONPath with -- `JSON.STRLEN j .a` is `[5]`, not the `5` RedisJSON sends. Under RESP2,
+        for a JSONPath, and for a null -- which is what a path that matched nothing answers
+        with -- the two agree.
+        """
+        if res is None or not legacy or self.server_type != "dragonfly" or self._client_info.protocol_version != 3:
+            return res
+        return [res]
+
+    def _read_iterate(
+        self,
+        method: Callable[[JsonType], Any | None],
+        key: CommandItem,
+        *args: Any,
+        error_on_zero_matches: bool = False,
+    ) -> list[Any | None] | Any | None:
+        res = _json_read_iterate(
+            method, key, *args, error_on_zero_matches=error_on_zero_matches, server_type=self.server_type
+        )
+        return self._legacy_path_reply(res, _path_is_legacy(args[0] if len(args) > 0 else None))
+
+    def _write_iterate(
+        self,
+        method: Callable[[JsonType], tuple[JsonType | None, Any, bool]],
+        key: CommandItem,
+        path_str: str | bytes,
+        allow_result_none: bool = False,
+        legacy: bool | None = None,
+    ) -> list[Any | None] | Any | None:
+        """`legacy` overrides the path form for a command that defaults an omitted path to `$`."""
+        res = _json_write_iterate(
+            method, key, path_str, allow_result_none=allow_result_none, server_type=self.server_type
+        )
+        return self._legacy_path_reply(res, _path_is_legacy(path_str) if legacy is None else legacy)
+
     def _get_single(
+        self,
         key: CommandItem,
         path_str: str | bytes,
         always_return_list: bool = False,
         empty_list_as_none: bool = False,
     ) -> Any:
-        path: JSONPath = _parse_jsonpath(path_str)
+        path: JSONPath = _parse_jsonpath(path_str, self.server_type)
         path_value = path.find(key.value)
         val = [i.value for i in path_value]
         if empty_list_as_none and len(val) == 0:
@@ -318,7 +387,7 @@ class JSONCommandsMixin(CommandsMixinBase):
         if key.value is None:
             return 0
 
-        path = _parse_jsonpath(path_str)
+        path = _parse_jsonpath(path_str, self.server_type)
         if _path_is_root(path):
             delete_keys(key)
             return 1
@@ -335,9 +404,8 @@ class JSONCommandsMixin(CommandsMixinBase):
         key.update(curr_value)
         return res
 
-    @staticmethod
-    def _json_set(key: CommandItem, path_str: bytes, value: JsonType, *args: Any) -> SimpleString | None:
-        path = _parse_jsonpath(path_str)
+    def _json_set(self, key: CommandItem, path_str: bytes, value: JsonType, *args: Any) -> SimpleString | None:
+        path = _parse_jsonpath(path_str, self.server_type)
         if key.value is not None and (type(key.value) is not dict) and not _path_is_root(path):
             raise helpers.SimpleError(msgs.JSON_WRONG_REDIS_TYPE)
         old_value_list = path.find(key.value)
@@ -383,7 +451,7 @@ class JSONCommandsMixin(CommandsMixinBase):
         value = JSONObject.decode(value_bytes)
         if fpha is not None:
             value = _apply_fpha(value, fpha, value_bytes)
-        return JSONCommandsMixin._json_set(key, path_str, value, *left_args)
+        return self._json_set(key, path_str, value, *left_args)
 
     @command(name="JSON.GET", fixed=(Key(),), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
     def json_get(self, key: CommandItem, *args: bytes) -> bytes | None:
@@ -415,11 +483,11 @@ class JSONCommandsMixin(CommandsMixinBase):
         return result
 
     @command(name="JSON.TOGGLE", fixed=(Key(),), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
-    def json_toggle(self, key: CommandItem, *args: bytes) -> list[bool | None] | bool | None:
+    def json_toggle(self, key: CommandItem, *args: bytes) -> list[Any] | bytes | bool | None:
         if key.value is None:
-            raise helpers.SimpleError(msgs.JSON_KEY_NOT_FOUND)
+            raise _key_not_found(self.server_type)
         path_str = args[0] if len(args) > 0 else b"$"
-        path = _parse_jsonpath(path_str)
+        path = _parse_jsonpath(path_str, self.server_type)
         found_matches = path.find(key.value)
 
         curr_value = copy.deepcopy(key.value)
@@ -431,8 +499,16 @@ class JSONCommandsMixin(CommandsMixinBase):
             else:
                 res.append(None)
         if all(x is None for x in res):
-            raise helpers.SimpleError(msgs.JSON_KEY_NOT_FOUND)
+            raise _key_not_found(self.server_type)
         key.update(curr_value)
+
+        if self.server_type == "dragonfly":
+            # Dragonfly answers a legacy path with the JSON text of the new value and a
+            # JSONPath with 0/1, where RedisJSON answers with booleans either way.
+            if _path_is_legacy(path_str):
+                return self._legacy_path_reply(JSONObject.encode(res[0]), True)
+            toggled: list[Any] = [int(x) if type(x) is bool else x for x in res]
+            return toggled
 
         if len(res) == 1 and (len(args) == 0 or (len(args) == 1 and args[0] == b".")):
             return res[0]
@@ -442,9 +518,9 @@ class JSONCommandsMixin(CommandsMixinBase):
     @command(name="JSON.CLEAR", fixed=(Key(),), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
     def json_clear(self, key: CommandItem, *args: bytes) -> int:
         if key.value is None:
-            raise helpers.SimpleError(msgs.JSON_KEY_NOT_FOUND)
+            raise _key_not_found(self.server_type)
         path_str: bytes = args[0] if len(args) > 0 else b"$"
-        path = _parse_jsonpath(path_str)
+        path = _parse_jsonpath(path_str, self.server_type)
         found_matches = path.find(key.value)
         curr_value = copy.deepcopy(key.value)
         res = 0
@@ -472,7 +548,7 @@ class JSONCommandsMixin(CommandsMixinBase):
             else:
                 return None, None, False
 
-        return _json_write_iterate(strappend, key, path_str)
+        return self._write_iterate(strappend, key, path_str)
 
     @command(name="JSON.ARRAPPEND", fixed=(Key(), bytes), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
     def json_arrappend(
@@ -490,7 +566,7 @@ class JSONCommandsMixin(CommandsMixinBase):
             else:
                 return None, None, False
 
-        return _json_write_iterate(arrappend, key, path_str)
+        return self._write_iterate(arrappend, key, path_str)
 
     @command(name="JSON.ARRINSERT", fixed=(Key(), bytes, Int), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
     def json_arrinsert(
@@ -508,7 +584,7 @@ class JSONCommandsMixin(CommandsMixinBase):
             else:
                 return None, None, False
 
-        return _json_write_iterate(arrinsert, key, path_str)
+        return self._write_iterate(arrinsert, key, path_str)
 
     @command(name="JSON.ARRPOP", fixed=(Key(),), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
     def json_arrpop(self, key: CommandItem, *args: bytes) -> JsonType:
@@ -520,10 +596,19 @@ class JSONCommandsMixin(CommandsMixinBase):
                 ind = index if index < len(val) else -1
                 res = val.pop(ind)
                 return val, JSONObject.encode(res), True
-            else:
-                return None, None, False
+            # An empty array has nothing to pop; a match that is no array at all is reported
+            # differently again, so the two are told apart below rather than here.
+            return None, (None if type(val) is list else _NOT_AN_ARRAY), False  # type:ignore[return-value]
 
-        return _json_write_iterate(arrpop, key, path_str, allow_result_none=True)
+        res: Any = _json_write_iterate(arrpop, key, path_str, allow_result_none=True, server_type=self.server_type)
+        if isinstance(res, list):
+            return [None if item is _NOT_AN_ARRAY else item for item in res]
+        if res is _NOT_AN_ARRAY:
+            # Flattening a legacy path down to one value, dragonfly reports a match that is no
+            # array as the JSON text `null`, where RedisJSON sends a null reply.
+            res = b"null" if self.server_type == "dragonfly" else None
+        # An omitted path is a legacy path here, whatever the `$` default says.
+        return self._legacy_path_reply(res, _path_is_legacy(args[0] if len(args) > 0 else None))
 
     @command(name="JSON.ARRTRIM", fixed=(Key(),), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
     def json_arrtrim(self, key: CommandItem, *args: bytes) -> JsonType:
@@ -542,7 +627,7 @@ class JSONCommandsMixin(CommandsMixinBase):
             else:
                 return None, None, False
 
-        return _json_write_iterate(arrtrim, key, path_str)
+        return self._write_iterate(arrtrim, key, path_str, legacy=_path_is_legacy(args[0] if len(args) > 0 else None))
 
     @command(
         name="JSON.NUMINCRBY",
@@ -560,8 +645,7 @@ class JSONCommandsMixin(CommandsMixinBase):
             else:
                 return None, None, False
 
-        res: JsonType = self._resp3_wrapping_list(_json_write_iterate(numincrby, key, path_str))
-        return res
+        return self._number_reply(_json_write_iterate(numincrby, key, path_str, server_type=self.server_type))
 
     @command(
         name="JSON.NUMMULTBY",
@@ -577,8 +661,7 @@ class JSONCommandsMixin(CommandsMixinBase):
             else:
                 return None, None, False
 
-        res: JsonType = self._resp3_wrapping_list(_json_write_iterate(nummultby, key, path_str))
-        return res
+        return self._number_reply(_json_write_iterate(nummultby, key, path_str, server_type=self.server_type))
 
     # Read operations
     @command(name="JSON.ARRINDEX", fixed=(Key(), bytes, bytes), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
@@ -602,19 +685,19 @@ class JSONCommandsMixin(CommandsMixinBase):
             except StopIteration:
                 return -1
 
-        return _json_read_iterate(check_index, key, path_str, error_on_zero_matches=True)
+        return self._read_iterate(check_index, key, path_str, error_on_zero_matches=True)
 
     @command(name="JSON.STRLEN", fixed=(Key(),), repeat=(bytes,))
     def json_strlen(self, key: CommandItem, *args: bytes) -> list[int | None] | int | None:
-        return _json_read_iterate(lambda val: len(val) if type(val) is str else None, key, *args)
+        return self._read_iterate(lambda val: len(val) if type(val) is str else None, key, *args)
 
     @command(name="JSON.ARRLEN", fixed=(Key(),), repeat=(bytes,))
     def json_arrlen(self, key: CommandItem, *args: bytes) -> list[int | None] | int | None:
-        return _json_read_iterate(lambda val: len(val) if type(val) is list else None, key, *args)
+        return self._read_iterate(lambda val: len(val) if type(val) is list else None, key, *args)
 
     @command(name="JSON.OBJLEN", fixed=(Key(),), repeat=(bytes,))
     def json_objlen(self, key: CommandItem, *args: bytes) -> list[int | None] | int | None:
-        return _json_read_iterate(lambda val: len(val) if type(val) is dict else None, key, *args)
+        return self._read_iterate(lambda val: len(val) if type(val) is dict else None, key, *args)
 
     def _resp3_wrapping_list(self, res: Any, wrap_list: bool = False) -> Any:
         if self._client_info.protocol_version == 2:
@@ -623,14 +706,35 @@ class JSONCommandsMixin(CommandsMixinBase):
             return res
         return [res]
 
+    def _number_reply(self, res: JsonType) -> list[Any | None] | Any | None:
+        """Shape a JSON.NUMINCRBY / JSON.NUMMULTBY reply.
+
+        RedisJSON wraps the new value in an array under RESP3. Dragonfly does not, and
+        under RESP2 sends the JSON text of the value rather than the value itself.
+        """
+        if self.server_type != "dragonfly":
+            return self._resp3_wrapping_list(res)
+        if self._client_info.protocol_version == 2:
+            return JSONObject.encode(res)
+        return res
+
     @command(name="JSON.TYPE", fixed=(Key(),), repeat=(bytes,), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
     def json_type(self, key: CommandItem, *args: bytes) -> list[bytes | None] | bytes | None:
-        res = _json_read_iterate(lambda val: self.TYPE_NAMES.get(type(val), None), key, *args)
+        res = _json_read_iterate(
+            lambda val: self.TYPE_NAMES.get(type(val), None), key, *args, server_type=self.server_type
+        )
+        if self.server_type == "dragonfly":
+            if self._client_info.protocol_version == 3 and isinstance(res, list):
+                # Dragonfly wraps every match of a JSONPath in an array of its own, where
+                # RedisJSON wraps the whole reply in one.
+                wrapped: list[Any] = [[item] for item in res]
+                return wrapped
+            return self._legacy_path_reply(res, _path_is_legacy(args[0] if len(args) > 0 else None))
         return self._resp3_wrapping_list(res, wrap_list=True)  # type:ignore
 
     @command(name="JSON.OBJKEYS", fixed=(Key(),), repeat=(bytes,))
     def json_objkeys(self, key: CommandItem, *args: bytes) -> list[bytes | None] | bytes | None:
-        return _json_read_iterate(lambda val: [i.encode() for i in val] if type(val) is dict else None, key, *args)
+        return self._read_iterate(lambda val: [i.encode() for i in val] if type(val) is dict else None, key, *args)
 
     @command(name="JSON.MSET", fixed=(), repeat=(Key(), bytes, JSONObject), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
     def json_mset(self, *args: Any) -> SimpleString:
@@ -638,12 +742,12 @@ class JSONCommandsMixin(CommandsMixinBase):
             raise helpers.SimpleError(msgs.WRONG_ARGS_MSG6.format("json.mset"))
         for i in range(0, len(args), 3):
             key, path_str, value = args[i], args[i + 1], args[i + 2]
-            JSONCommandsMixin._json_set(key, path_str, value)
+            self._json_set(key, path_str, value)
         return helpers.OK
 
     @command(name="JSON.MERGE", fixed=(Key(), bytes, JSONObject), repeat=(), flags=msgs.FLAG_LEAVE_EMPTY_VAL)
     def json_merge(self, key: CommandItem, path_str: bytes, value: JsonType) -> SimpleString:
-        path: JSONPath = _parse_jsonpath(path_str)
+        path: JSONPath = _parse_jsonpath(path_str, self.server_type)
         if key.value is not None and (type(key.value) is not dict) and not _path_is_root(path):
             raise helpers.SimpleError(msgs.JSON_WRONG_REDIS_TYPE)
         matching = path.find(key.value)

--- a/test/test_stack/test_json.py
+++ b/test/test_stack/test_json.py
@@ -10,6 +10,7 @@ import valkey
 from redis.commands.json.path import Path
 
 from test import testtools
+from test.conftest import ServerDetails
 
 json_tests = pytest.importorskip("jsonpath_ng")
 
@@ -218,14 +219,15 @@ def test_jsonclear_no_doc(r: redis.Redis):
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 
 
-def test_jsonstrlen(r: redis.Redis):
+def test_jsonstrlen(r: redis.Redis, real_server_details: ServerDetails):
+    server_type = real_server_details.server_type
     data = {"x": "bar", "y": {"x": 33}}
     r.json().set("foo", Path.root_path(), data)
     assert r.json().strlen("foo", Path("$..x")) == [3, None]
 
     r.json().set("foo2", Path.root_path(), "data2")
-    assert r.json().strlen("foo2") == 5
-    assert r.json().strlen("foo2", Path.root_path()) == 5
+    assert r.json().strlen("foo2") == testtools.json_legacy_reply(r, server_type, 5)
+    assert r.json().strlen("foo2", Path.root_path()) == testtools.json_legacy_reply(r, server_type, 5)
 
     r.json().set("foo3", Path.root_path(), {"x": "string"})
     assert r.json().strlen("foo3", Path("$.x")) == [6]
@@ -233,7 +235,7 @@ def test_jsonstrlen(r: redis.Redis):
     assert r.json().strlen("non-existing") is None
 
     r.json().set("str", Path.root_path(), "foo")
-    assert r.json().strlen("str", Path.root_path()) == 3
+    assert r.json().strlen("str", Path.root_path()) == testtools.json_legacy_reply(r, server_type, 3)
     # Test multi
     r.json().set("doc1", "$", {"a": "foo", "nested1": {"a": "hello"}, "nested2": {"a": 31}})
     assert r.json().strlen("doc1", "$..a") == [3, 5, None]
@@ -250,13 +252,18 @@ def test_jsonstrlen(r: redis.Redis):
     with pytest.raises(Exception) as ctx:
         r.json().strlen("non_existing_doc", "$..a")
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
-    assert str(ctx.value) == "could not perform this operation on a key that doesn't exist"
+    # Dragonfly reports a missing key in its own, shorter wording.
+    if server_type == "dragonfly":
+        assert str(ctx.value) == "no such key"
+    else:
+        assert str(ctx.value) == "could not perform this operation on a key that doesn't exist"
 
 
-def test_toggle(r: redis.Redis):
+def test_toggle(r: redis.Redis, real_server_details: ServerDetails):
+    server_type = real_server_details.server_type
     r.json().set("bool", Path.root_path(), False)
-    assert r.json().toggle("bool", Path.root_path())
-    assert r.json().toggle("bool", Path.root_path()) is False
+    assert r.json().toggle("bool", Path.root_path()) == testtools.json_toggle_reply(r, server_type, True)
+    assert r.json().toggle("bool", Path.root_path()) == testtools.json_toggle_reply(r, server_type, False)
 
     r.json().set("num", Path.root_path(), 1)
 
@@ -311,10 +318,10 @@ def test_json_commands_in_pipeline(r: redis.Redis):
     assert r.get("foo") is None
 
 
-def test_strappend(r: redis.Redis):
+def test_strappend(r: redis.Redis, real_server_details: ServerDetails):
     # Test single
     r.json().set("json-key", Path.root_path(), "foo")
-    assert r.json().strappend("json-key", "bar") == 6
+    assert r.json().strappend("json-key", "bar") == testtools.json_legacy_reply(r, real_server_details.server_type, 6)
     assert "foobar" == r.json().get("json-key", Path.root_path())
 
     # Test multi
@@ -419,7 +426,8 @@ def test_set_path(r: redis.Redis):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
-def test_type(r: redis.Redis):
+def test_type(r: redis.Redis, real_server_details: ServerDetails):
+    server_type = real_server_details.server_type
     r.json().set("1", Path.root_path(), 1)
 
     assert r.json().type("1", Path.root_path()) == testtools.resp_conversion(r, [b"integer"], b"integer")
@@ -444,20 +452,21 @@ def test_type(r: redis.Redis):
             if v == val:
                 expected.append(k.encode())
                 break
-    assert r.json().type("doc1", "$..a") == testtools.resp_conversion(r, [expected], expected)
+    assert r.json().type("doc1", "$..a") == testtools.json_type_reply(r, server_type, expected)
 
     # Test single
     assert r.json().type("doc1", "$.integer.a") == testtools.resp_conversion(r, [[b"integer"]], [b"integer"])
     assert r.json().type("doc1") == testtools.resp_conversion(r, [b"object"], b"object")
 
-    # Test missing key
-    if testtools.get_protocol_version(r) == 2:
+    # Test missing key. Dragonfly answers a legacy path with a plain null under RESP3 too.
+    if testtools.get_protocol_version(r) == 2 or server_type == "dragonfly":
         assert r.json().type("non_existing_doc", "..a") is None
     else:
         assert r.json().type("non_existing_doc", "..a") == [None]
 
 
-def test_objlen(r: redis.Redis):
+def test_objlen(r: redis.Redis, real_server_details: ServerDetails):
+    server_type = real_server_details.server_type
     # Test missing key, and path
     with pytest.raises(Exception) as ctx:
         r.json().objlen("non_existing_doc", "$..a")
@@ -466,10 +475,10 @@ def test_objlen(r: redis.Redis):
     obj = {"foo": "bar", "baz": "qaz"}
 
     r.json().set("obj", Path.root_path(), obj)
-    assert len(obj) == r.json().objlen("obj", Path.root_path())
+    assert r.json().objlen("obj", Path.root_path()) == testtools.json_legacy_reply(r, server_type, len(obj))
 
     r.json().set("obj", Path.root_path(), obj)
-    assert len(obj) == r.json().objlen("obj")
+    assert r.json().objlen("obj") == testtools.json_legacy_reply(r, server_type, len(obj))
     r.json().set(
         "doc1",
         "$",
@@ -483,10 +492,10 @@ def test_objlen(r: redis.Redis):
     assert r.json().objlen("doc1", "$.nowhere") == []
 
     # Test legacy
-    assert r.json().objlen("doc1", ".*.a") == 2
+    assert r.json().objlen("doc1", ".*.a") == testtools.json_legacy_reply(r, server_type, 2)
 
     # Test single
-    assert r.json().objlen("doc1", ".nested2.a") == 1
+    assert r.json().objlen("doc1", ".nested2.a") == testtools.json_legacy_reply(r, server_type, 1)
 
     # Test missing key
     assert r.json().objlen("non_existing_doc", "..a") is None
@@ -496,17 +505,20 @@ def test_objlen(r: redis.Redis):
     r.json().objlen("doc1", ".nowhere")
 
 
-def test_objkeys(r: redis.Redis):
+def test_objkeys(r: redis.Redis, real_server_details: ServerDetails):
+    server_type = real_server_details.server_type
     obj = {"foo": "bar", "baz": "qaz"}
     r.json().set("obj", Path.root_path(), obj)
-    keys = r.json().objkeys("obj", Path.root_path())
+    keys = testtools.json_legacy_value(r, server_type, r.json().objkeys("obj", Path.root_path()))
     keys.sort()
     exp = [k.encode() for k in obj]
     exp.sort()
     assert set(keys) == testtools.resp_conversion(r, {k.encode() for k in obj}, set(obj.keys()))
 
     r.json().set("obj", Path.root_path(), obj)
-    assert set(r.json().objkeys("obj")) == testtools.resp_conversion(r, {k.encode() for k in obj}, set(obj.keys()))
+    assert set(testtools.json_legacy_value(r, server_type, r.json().objkeys("obj"))) == testtools.resp_conversion(
+        r, {k.encode() for k in obj}, set(obj.keys())
+    )
 
     assert r.json().objkeys("fakekey") is None
 
@@ -519,9 +531,13 @@ def test_objkeys(r: redis.Redis):
     assert set(keys[0]) == {b"foo", b"bar"}
 
     # Test legacy
-    assert set(r.json().objkeys("doc1", ".*.a")) == testtools.resp_conversion(r, {b"foo", b"bar"}, {"foo", "bar"})
+    assert set(
+        testtools.json_legacy_value(r, server_type, r.json().objkeys("doc1", ".*.a"))
+    ) == testtools.resp_conversion(r, {b"foo", b"bar"}, {"foo", "bar"})
     # Test single
-    assert r.json().objkeys("doc1", ".nested2.a") == testtools.resp_conversion(r, [b"baz"], ["baz"])
+    assert r.json().objkeys("doc1", ".nested2.a") == testtools.json_legacy_reply(
+        r, server_type, testtools.resp_conversion(r, [b"baz"], ["baz"])
+    )
 
     # Test missing key
     assert r.json().objkeys("non_existing_doc", "..a") is None
@@ -535,12 +551,13 @@ def test_objkeys(r: redis.Redis):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
-def test_numincrby(r: redis.Redis):
+def test_numincrby(r: redis.Redis, real_server_details: ServerDetails):
+    server_type = real_server_details.server_type
     r.json().set("num", Path.root_path(), 1)
 
-    assert r.json().numincrby("num", Path.root_path(), 1) == testtools.resp_conversion(r, [2], 2)
-    assert r.json().numincrby("num", Path.root_path(), 0.5) == testtools.resp_conversion(r, [2.5], 2.5)
-    assert r.json().numincrby("num", Path.root_path(), -1.25) == testtools.resp_conversion(r, [1.25], 1.25)
+    assert r.json().numincrby("num", Path.root_path(), 1) == testtools.json_number_reply(r, server_type, 2)
+    assert r.json().numincrby("num", Path.root_path(), 0.5) == testtools.json_number_reply(r, server_type, 2.5)
+    assert r.json().numincrby("num", Path.root_path(), -1.25) == testtools.json_number_reply(r, server_type, 1.25)
     # Test NUMINCRBY
     r.json().set("doc1", "$", {"a": "b", "b": [{"a": 2}, {"a": 5.0}, {"a": "c"}]})
     # Test multi
@@ -555,13 +572,14 @@ def test_numincrby(r: redis.Redis):
 
 
 @pytest.mark.supported_server_versions(min_redis_ver="7")
-def test_nummultby(r: redis.Redis):
+def test_nummultby(r: redis.Redis, real_server_details: ServerDetails):
+    server_type = real_server_details.server_type
     r.json().set("num", Path.root_path(), 1)
 
     with pytest.deprecated_call():
-        assert r.json().nummultby("num", Path.root_path(), 2) == testtools.resp_conversion(r, [2], 2)
-        assert r.json().nummultby("num", Path.root_path(), 2.5) == testtools.resp_conversion(r, [5], 5)
-        assert r.json().nummultby("num", Path.root_path(), 0.5) == testtools.resp_conversion(r, [2.5], 2.5)
+        assert r.json().nummultby("num", Path.root_path(), 2) == testtools.json_number_reply(r, server_type, 2)
+        assert r.json().nummultby("num", Path.root_path(), 2.5) == testtools.json_number_reply(r, server_type, 5)
+        assert r.json().nummultby("num", Path.root_path(), 0.5) == testtools.json_number_reply(r, server_type, 2.5)
 
     r.json().set("doc1", "$", {"a": "b", "b": [{"a": 2}, {"a": 5.0}, {"a": "c"}]})
 
@@ -584,13 +602,13 @@ def test_nummultby(r: redis.Redis):
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
     # Test legacy NUMINCRBY
     r.json().set("doc1", "$", {"a": "b", "b": [{"a": 2}, {"a": 5.0}, {"a": "c"}]})
-    assert r.json().numincrby("doc1", ".b[0].a", 3) == testtools.resp_conversion(r, [5], 5)
+    assert r.json().numincrby("doc1", ".b[0].a", 3) == testtools.json_number_reply(r, server_type, 5)
 
     # Test legacy NUMMULTBY
     r.json().set("doc1", "$", {"a": "b", "b": [{"a": 2}, {"a": 5.0}, {"a": "c"}]})
 
     with pytest.deprecated_call():
-        assert r.json().nummultby("doc1", ".b[0].a", 3) == testtools.resp_conversion(r, [6], 6)
+        assert r.json().nummultby("doc1", ".b[0].a", 3) == testtools.json_number_reply(r, server_type, 6)
 
 
 @testtools.run_test_if_redispy_ver("gte", "4.6")

--- a/test/test_stack/test_json_arr_commands.py
+++ b/test/test_stack/test_json_arr_commands.py
@@ -3,15 +3,18 @@ import redis
 import valkey
 from redis.commands.json.path import Path
 
+from test import testtools
+from test.conftest import ServerDetails
 from test.testtools import raw_command
 
 json_tests = pytest.importorskip("jsonpath_ng")
 
 
-def test_arrlen(r: redis.Redis):
+def test_arrlen(r: redis.Redis, real_server_details: ServerDetails):
+    server_type = real_server_details.server_type
     r.json().set("arr", Path.root_path(), [0, 1, 2, 3, 4])
-    assert r.json().arrlen("arr", Path.root_path()) == 5
-    assert r.json().arrlen("arr") == 5
+    assert r.json().arrlen("arr", Path.root_path()) == testtools.json_legacy_reply(r, server_type, 5)
+    assert r.json().arrlen("arr") == testtools.json_legacy_reply(r, server_type, 5)
     assert r.json().arrlen("fake-key") is None
 
     r.json().set(
@@ -23,7 +26,7 @@ def test_arrlen(r: redis.Redis):
 
     r.json().set("doc2", "$", {"a": ["foo"], "nested1": {"a": ["hello", 1, 1, None, "world"]}, "nested2": {"a": 31}})
     assert r.json().arrlen("doc2", "$..a") == [1, 5, None]
-    assert r.json().arrlen("doc2", ".nested1.a") == 5
+    assert r.json().arrlen("doc2", ".nested1.a") == testtools.json_legacy_reply(r, server_type, 5)
     r.json().set("doc1", "$", {"a": ["foo"], "nested1": {"a": ["hello", None, "world"]}, "nested2": {"a": 31}})
 
     # Test multi
@@ -42,23 +45,24 @@ def test_arrlen(r: redis.Redis):
     r.json().set("doc1", "$", {"a": ["foo"], "nested1": {"a": ["hello", None, "world"]}, "nested2": {"a": 31}})
     # Test multi (return result of last path)
     assert r.json().arrlen("doc1", "$..a") == [1, 3, None]
-    assert r.json().arrappend("doc1", "..a", "non", "abba", "stanza") == 6
+    assert r.json().arrappend("doc1", "..a", "non", "abba", "stanza") == testtools.json_legacy_reply(r, server_type, 6)
 
     # Test single
-    assert r.json().arrlen("doc1", ".nested1.a") == 6
+    assert r.json().arrlen("doc1", ".nested1.a") == testtools.json_legacy_reply(r, server_type, 6)
 
     # Test missing key
     assert r.json().arrlen("non_existing_doc", "..a") is None
 
 
-def test_arrappend(r: redis.Redis):
+def test_arrappend(r: redis.Redis, real_server_details: ServerDetails):
+    server_type = real_server_details.server_type
     with pytest.raises(Exception) as ctx:
         r.json().arrappend("non-existing-key", Path.root_path(), 2)
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
     r.json().set("arr", Path.root_path(), [1])
-    assert r.json().arrappend("arr", Path.root_path(), 2) == 2
-    assert r.json().arrappend("arr", Path.root_path(), 3, 4) == 4
-    assert r.json().arrappend("arr", Path.root_path(), *[5, 6, 7]) == 7
+    assert r.json().arrappend("arr", Path.root_path(), 2) == testtools.json_legacy_reply(r, server_type, 2)
+    assert r.json().arrappend("arr", Path.root_path(), 3, 4) == testtools.json_legacy_reply(r, server_type, 4)
+    assert r.json().arrappend("arr", Path.root_path(), *[5, 6, 7]) == testtools.json_legacy_reply(r, server_type, 7)
     assert r.json().get("arr") == [1, 2, 3, 4, 5, 6, 7]
     r.json().set("doc1", "$", {"a": ["foo"], "nested1": {"a": ["hello", None, "world"]}, "nested2": {"a": 31}})
     # Test multi
@@ -75,7 +79,7 @@ def test_arrappend(r: redis.Redis):
     # Test legacy
     r.json().set("doc1", "$", {"a": ["foo"], "nested1": {"a": ["hello", None, "world"]}, "nested2": {"a": 31}})
     # Test multi (all paths are updated, but return result of last path)
-    assert r.json().arrappend("doc1", "..a", "bar", "racuda") == 5
+    assert r.json().arrappend("doc1", "..a", "bar", "racuda") == testtools.json_legacy_reply(r, server_type, 5)
 
     assert r.json().get("doc1", "$") == [
         {
@@ -85,7 +89,7 @@ def test_arrappend(r: redis.Redis):
         }
     ]
     # Test single
-    assert r.json().arrappend("doc1", ".nested1.a", "baz") == 6
+    assert r.json().arrappend("doc1", ".nested1.a", "baz") == testtools.json_legacy_reply(r, server_type, 6)
     assert r.json().get("doc1", "$") == [
         {
             "a": ["foo", "bar", "racuda"],
@@ -100,11 +104,12 @@ def test_arrappend(r: redis.Redis):
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 
 
-def test_arrindex(r: redis.Redis):
+def test_arrindex(r: redis.Redis, real_server_details: ServerDetails):
+    server_type = real_server_details.server_type
     r.json().set("foo", Path.root_path(), [0, 1, 2, 3, 4])
 
-    assert r.json().arrindex("foo", Path.root_path(), 1) == 1
-    assert r.json().arrindex("foo", Path.root_path(), 1, 2) == -1
+    assert r.json().arrindex("foo", Path.root_path(), 1) == testtools.json_legacy_reply(r, server_type, 1)
+    assert r.json().arrindex("foo", Path.root_path(), 1, 2) == testtools.json_legacy_reply(r, server_type, -1)
 
     r.json().set(
         "store",
@@ -148,8 +153,13 @@ def test_arrindex(r: redis.Redis):
         },
     )
 
-    assert r.json().get("store", "$.store.book[?(@.price<10)].size") == [[10, 20, 30, 40], [5, 10, 20, 30]]
-    assert r.json().arrindex("store", "$.store.book[?(@.price<10)].size", "20") == [-1, -1]
+    # Dragonfly's JSONPath has no filter expressions, so `[?(...)]` never gets as far as matching.
+    if server_type == "dragonfly":
+        with pytest.raises((redis.ResponseError, valkey.ResponseError), match="syntax error"):
+            r.json().get("store", "$.store.book[?(@.price<10)].size")
+    else:
+        assert r.json().get("store", "$.store.book[?(@.price<10)].size") == [[10, 20, 30, 40], [5, 10, 20, 30]]
+        assert r.json().arrindex("store", "$.store.book[?(@.price<10)].size", "20") == [-1, -1]
 
     # Test index of int scalar in multi values
     r.json().set(
@@ -234,29 +244,34 @@ def test_arrindex(r: redis.Redis):
 
     # Test legacy (path begins with dot)
     # Test index of int scalar in single value
-    assert r.json().arrindex("test_num", ".[0].arr", 3) == 3
-    assert r.json().arrindex("test_num", ".[0].arr", 9) == -1
+    assert r.json().arrindex("test_num", ".[0].arr", 3) == testtools.json_legacy_reply(r, server_type, 3)
+    assert r.json().arrindex("test_num", ".[0].arr", 9) == testtools.json_legacy_reply(r, server_type, -1)
 
     with pytest.raises(Exception) as ctx:
         r.json().arrindex("test_num", ".[0].arr_not", 3)
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
     # Test index of string scalar in single value
-    assert r.json().arrindex("test_string", ".[0].arr", "baz") == 3
-    assert r.json().arrindex("test_string", ".[0].arr", "faz") == -1
+    assert r.json().arrindex("test_string", ".[0].arr", "baz") == testtools.json_legacy_reply(r, server_type, 3)
+    assert r.json().arrindex("test_string", ".[0].arr", "faz") == testtools.json_legacy_reply(r, server_type, -1)
     # Test index of None scalar in single value
-    assert r.json().arrindex("test_None", ".[0].arr", "None") == 1
-    assert r.json().arrindex("test_None", "..nested2_not_found.arr", "None") == 0
+    assert r.json().arrindex("test_None", ".[0].arr", "None") == testtools.json_legacy_reply(r, server_type, 1)
+    assert r.json().arrindex("test_None", "..nested2_not_found.arr", "None") == testtools.json_legacy_reply(
+        r, server_type, 0
+    )
 
 
-def test_arrinsert(r: redis.Redis):
+def test_arrinsert(r: redis.Redis, real_server_details: ServerDetails):
+    server_type = real_server_details.server_type
     r.json().set("arr", Path.root_path(), [0, 4])
 
-    assert r.json().arrinsert("arr", Path.root_path(), 1, *[1, 2, 3]) == 5
+    assert r.json().arrinsert("arr", Path.root_path(), 1, *[1, 2, 3]) == testtools.json_legacy_reply(r, server_type, 5)
     assert r.json().get("arr") == [0, 1, 2, 3, 4]
 
     # test prepends
     r.json().set("val2", Path.root_path(), [5, 6, 7, 8, 9])
-    assert r.json().arrinsert("val2", Path.root_path(), 0, ["some", "thing"]) == 6
+    assert r.json().arrinsert("val2", Path.root_path(), 0, ["some", "thing"]) == testtools.json_legacy_reply(
+        r, server_type, 6
+    )
     assert r.json().get("val2") == [["some", "thing"], 5, 6, 7, 8, 9]
     r.json().set("doc1", "$", {"a": ["foo"], "nested1": {"a": ["hello", None, "world"]}, "nested2": {"a": 31}})
     # Test multi
@@ -285,20 +300,21 @@ def test_arrinsert(r: redis.Redis):
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 
 
-def test_arrpop(r: redis.Redis):
+def test_arrpop(r: redis.Redis, real_server_details: ServerDetails):
+    server_type = real_server_details.server_type
     r.json().set("arr", Path.root_path(), [0, 1, 2, 3, 4])
-    assert raw_command(r, "json.arrpop", "arr") == b"4"
+    assert raw_command(r, "json.arrpop", "arr") == testtools.json_legacy_reply(r, server_type, b"4")
 
     r.json().set("arr", Path.root_path(), [0, 1, 2, 3, 4])
-    assert r.json().arrpop("arr", Path.root_path(), 4) == 4
-    assert r.json().arrpop("arr", Path.root_path(), -1) == 3
-    assert r.json().arrpop("arr", Path.root_path()) == 2
-    assert r.json().arrpop("arr", Path.root_path(), 0) == 0
+    assert r.json().arrpop("arr", Path.root_path(), 4) == testtools.json_arrpop_reply(r, server_type, 4)
+    assert r.json().arrpop("arr", Path.root_path(), -1) == testtools.json_arrpop_reply(r, server_type, 3)
+    assert r.json().arrpop("arr", Path.root_path()) == testtools.json_arrpop_reply(r, server_type, 2)
+    assert r.json().arrpop("arr", Path.root_path(), 0) == testtools.json_arrpop_reply(r, server_type, 0)
     assert r.json().get("arr") == [1]
 
     # test out of bounds
     r.json().set("arr", Path.root_path(), [0, 1, 2, 3, 4])
-    assert r.json().arrpop("arr", Path.root_path(), 99) == 4
+    assert r.json().arrpop("arr", Path.root_path(), 99) == testtools.json_arrpop_reply(r, server_type, 4)
 
     # none test
     r.json().set("arr", Path.root_path(), [])
@@ -309,7 +325,7 @@ def test_arrpop(r: redis.Redis):
     # # Test legacy
     r.json().set("doc1", "$", {"a": ["foo"], "nested1": {"a": ["hello", None, "world"]}, "nested2": {"a": 31}})
     # Test multi (all paths are updated, but return result of last path)
-    assert r.json().arrpop("doc1", "..a", "1") is None
+    assert r.json().arrpop("doc1", "..a", "1") == testtools.json_legacy_reply(r, server_type, None)
     assert r.json().get("doc1", "$") == [{"a": [], "nested1": {"a": ["hello", "world"]}, "nested2": {"a": 31}}]
 
     # # Test missing key
@@ -319,27 +335,28 @@ def test_arrpop(r: redis.Redis):
     assert isinstance(ctx.value, (redis.ResponseError, valkey.ResponseError))
 
 
-def test_arrtrim(r: redis.Redis):
+def test_arrtrim(r: redis.Redis, real_server_details: ServerDetails):
+    server_type = real_server_details.server_type
     r.json().set("arr", Path.root_path(), [0, 1, 2, 3, 4])
 
-    assert r.json().arrtrim("arr", Path.root_path(), 1, 3) == 3
+    assert r.json().arrtrim("arr", Path.root_path(), 1, 3) == testtools.json_legacy_reply(r, server_type, 3)
     assert r.json().get("arr") == [1, 2, 3]
 
     # <0 test, should be 0 equivalent
     r.json().set("arr", Path.root_path(), [0, 1, 2, 3, 4])
-    assert r.json().arrtrim("arr", Path.root_path(), -1, 3) == 0
+    assert r.json().arrtrim("arr", Path.root_path(), -1, 3) == testtools.json_legacy_reply(r, server_type, 0)
 
     # testing stop > end
     r.json().set("arr", Path.root_path(), [0, 1, 2, 3, 4])
-    assert r.json().arrtrim("arr", Path.root_path(), 3, 99) == 2
+    assert r.json().arrtrim("arr", Path.root_path(), 3, 99) == testtools.json_legacy_reply(r, server_type, 2)
 
     # start > array size and stop
     r.json().set("arr", Path.root_path(), [0, 1, 2, 3, 4])
-    assert r.json().arrtrim("arr", Path.root_path(), 9, 1) == 0
+    assert r.json().arrtrim("arr", Path.root_path(), 9, 1) == testtools.json_legacy_reply(r, server_type, 0)
 
     # all larger
     r.json().set("arr", Path.root_path(), [0, 1, 2, 3, 4])
-    assert r.json().arrtrim("arr", Path.root_path(), 9, 11) == 0
+    assert r.json().arrtrim("arr", Path.root_path(), 9, 11) == testtools.json_legacy_reply(r, server_type, 0)
 
     r.json().set("doc1", "$", {"a": ["foo"], "nested1": {"a": ["hello", None, "world"]}, "nested2": {"a": 31}})
     # Test multi
@@ -362,10 +379,10 @@ def test_arrtrim(r: redis.Redis):
     r.json().set("doc1", "$", {"a": ["foo"], "nested1": {"a": ["hello", None, "world"]}, "nested2": {"a": 31}})
 
     # Test multi (all paths are updated, but return result of last path)
-    assert r.json().arrtrim("doc1", "..a", "1", "-1") == 2
+    assert r.json().arrtrim("doc1", "..a", "1", "-1") == testtools.json_legacy_reply(r, server_type, 2)
 
     # Test single
-    assert r.json().arrtrim("doc1", ".nested1.a", "1", "1") == 1
+    assert r.json().arrtrim("doc1", ".nested1.a", "1", "1") == testtools.json_legacy_reply(r, server_type, 1)
     assert r.json().get("doc1", "$") == [{"a": [], "nested1": {"a": ["world"]}, "nested2": {"a": 31}}]
 
     # Test missing key

--- a/test/testtools.py
+++ b/test/testtools.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import inspect
 import itertools
+import json
 import time
 from datetime import datetime
 from typing import Any
@@ -174,6 +175,73 @@ def disable_xread_parsing(r: ClientType, server_type: str) -> bool:
         return False
     r.response_callbacks.pop("XREAD", None)
     return True
+
+
+def json_legacy_reply(r: ClientType, server_type: str, value: Any) -> Any:
+    """What a JSON command answers with for a legacy path (`.a`) on the server under test.
+
+    RedisJSON sends the value itself. Dragonfly sends the one-element array it sends for the
+    equivalent JSONPath, but only under RESP3; under RESP2 the two agree.
+    """
+    if server_type == "dragonfly" and get_protocol_version(r) == 3:
+        return [value]
+    return value
+
+
+def json_legacy_value(r: ClientType, server_type: str, reply: Any) -> Any:
+    """The value inside a legacy-path JSON reply, for tests that post-process it.
+
+    The inverse of `json_legacy_reply`: it unwraps the one-element array dragonfly answers a
+    legacy path with under RESP3, and leaves every other reply alone.
+    """
+    if server_type == "dragonfly" and get_protocol_version(r) == 3:
+        assert isinstance(reply, list) and len(reply) == 1, reply
+        return reply[0]
+    return reply
+
+
+def json_arrpop_reply(r: ClientType, server_type: str, value: Any) -> Any:
+    """What JSON.ARRPOP answers with for a legacy path on the server under test.
+
+    The reply is the JSON text of the popped element, which redis-py parses back into a value
+    -- but not through the array dragonfly wraps it in under RESP3, where it stays text.
+    """
+    if server_type == "dragonfly" and get_protocol_version(r) == 3:
+        return [json.dumps(value)]
+    return value
+
+
+def json_toggle_reply(r: ClientType, server_type: str, value: bool) -> Any:
+    """What JSON.TOGGLE answers with for a legacy path on the server under test.
+
+    Dragonfly answers with the JSON text of the new value, wrapped under RESP3 the way every
+    legacy path is; redis-py parses the bare text back into a boolean, so only the wrapped
+    reply differs from the boolean RedisJSON sends.
+    """
+    if server_type == "dragonfly" and get_protocol_version(r) == 3:
+        return ["true" if value else "false"]
+    return value
+
+
+def json_type_reply(r: ClientType, server_type: str, types: list[Any]) -> Any:
+    """What JSON.TYPE answers with for a JSONPath on the server under test.
+
+    Under RESP3 RedisJSON wraps the whole list of matched types in one array, where dragonfly
+    wraps each match in an array of its own. Under RESP2 neither wraps.
+    """
+    if get_protocol_version(r) == 2:
+        return types
+    return [[item] for item in types] if server_type == "dragonfly" else [types]
+
+
+def json_number_reply(r: ClientType, server_type: str, value: float) -> Any:
+    """What JSON.NUMINCRBY / JSON.NUMMULTBY answers with for a legacy path.
+
+    RedisJSON wraps the new value in an array under RESP3; dragonfly never does.
+    """
+    if server_type == "dragonfly":
+        return value
+    return resp_conversion(r, [value], value)
 
 
 def assert_empty_stream_read(r: redis.Redis, server_type: str, *raw_args: Any) -> None:


### PR DESCRIPTION
Dragonfly ships its own JSON implementation rather than RedisJSON, and the two
disagree mostly about how a *legacy* path (`.a`, as opposed to the JSONPath
`$.a`) is answered under RESP3.

* RedisJSON sends the value itself for a legacy path. Dragonfly sends the
  one-element array it sends for the equivalent JSONPath -- but only under
  RESP3; under RESP2 the two agree. JSON.ARRPOP and JSON.TOGGLE inherit the
  wrapping, which means their replies stay JSON *text* rather than being parsed
  back into a value by redis-py.
* JSON.TYPE goes the other way: RedisJSON wraps the whole list of matched types
  in one array under RESP3, where Dragonfly wraps each match in an array of its
  own.
* JSON.NUMINCRBY/NUMMULTBY never wrap, where RedisJSON wraps the new value in an
  array under RESP3.
* Flattening a legacy path down to one value, Dragonfly reports a match that is
  no value as the JSON text `null` rather than nil.
* Its JSONPath has no filter expressions at all -- `$.a[?(@.b>1)]` is a syntax
  error, not an empty match.
* A missing key is the plain "no such key", where RedisJSON spells the operation
  out.

The per-command reply shaping lives in `test/testtools.py` (`json_legacy_reply`,
`json_type_reply`, ...) so the shared tests can state the RedisJSON answer and
have the Dragonfly one derived from it, rather than branching in each assertion.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!--STACK-->
### This PR is part of a stack

`#373` split into twelve reviewable pieces. Each branches off the one above it, so they
merge in order; the diff shown here is only this step's own changes.

**#553 and #554 are merged.** #554 went into `df/01-prep` first, so master's squash commit
`b22d569e` carries both; the rest of the stack has been rebased onto master accordingly.

| PR | Branch | What it covers |
|---|--------|----------------|
| ~~#553~~ ✅ | `df/01-prep` | Server-agnostic fixes: SMOVE, BITCOUNT, GEO ordering, shared zset reply shaping |
| ~~#554~~ ✅ | `df/02-harness` | Build `FakeServer` with the Redis version Dragonfly reports; TCP server + CI plumbing |
| #555 | `df/03-errors` | Error wording and argument validation |
| #556 | `df/04-limits` | Expiry horizon, hash-field TTL cap, 256MB value cap |
| #557 | `df/05-reply-shapes` | Doubles, timed-out blocking pops, sorted-set reply shapes |
| #558 | `df/06-streams` | XREAD/XREADGROUP/XINFO/XPENDING replies |
| #559 | `df/07-pubsub` | Shard and plain channels in one namespace |
| #560 | `df/08-sort-copy-geo` | SORT patterns, COPY without DB, GEO ordering |
| #561 | `df/09-transactions` | WATCH invalidation and MULTI queueing |
| #562 | `df/10-scripting` | Lua 5.4 semantics and script error wording |
| #563 | `df/11-json` | Dragonfly's own JSON implementation |
| #564 | `df/12-hypothesis-docs` | Hypothesis guards + `docs/dragonfly-support.md` |

Verified against a real Dragonfly (`df-v1.40.1`) and a real Redis (`8.4.0`, all modules loaded): every
branch in the stack has an identical failure set to `master`, and the tip of the stack has two
*fewer* failures than `master` (PR #559 repairs a pre-existing pub/sub subscription leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
