### PR TITLE
feat(kividb): add the kividb server type

### DIFF
--- a/fakeredis/_commands.py
+++ b/fakeredis/_commands.py
@@ -301,7 +301,7 @@ class Signature:
         repeat: tuple[type[RedisType | bytes]] = (),  # type:ignore
         args: tuple[str] = (),  # type:ignore
         flags: str = "",
-        server_types: Collection[ServerType] = ("redis", "valkey", "dragonfly"),
+        server_types: Collection[ServerType] = ("redis", "valkey", "dragonfly", "kividb"),
     ):
         self.name = name
         self.func_name = func_name

--- a/fakeredis/_connection.py
+++ b/fakeredis/_connection.py
@@ -104,7 +104,7 @@ class FakeRedisMixin:
         """
         :param server: The FakeServer instance to use for this connection.
         :param version: The Redis version to use, as a tuple (major, minor).
-        :param server_type: The type of server, e.g., "redis", "valkey".
+        :param server_type: The type of server, e.g., "redis", "valkey", "dragonfly", "kividb".
         :param lua_modules: A set of Lua modules to load.
         :param client_class: The Redis client class to use, e.g., redis.Redis or valkey.Valkey.
         """

--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -45,7 +45,7 @@ class FakeServer:
     ) -> None:
         """Initialize a new FakeServer instance.
         :param version: The version of the server (e.g. 6, 7.4, "7.4.1", can also be a tuple)
-        :param server_type: The type of server (redis, dragonfly, valkey)
+        :param server_type: The type of server (redis, dragonfly, valkey, kividb)
         :param config: A dictionary of configuration options.
 
         Configuration options:
@@ -65,7 +65,7 @@ class FakeServer:
         self.sockets: list[Any] = []
         self.closed_sockets: list[Any] = []
         self.version: VersionType = _create_version(version)
-        if server_type not in ("redis", "dragonfly", "valkey"):
+        if server_type not in ("redis", "dragonfly", "valkey", "kividb"):
             raise ValueError(f"Unsupported server type: {server_type}")
         self.server_type: ServerType = server_type
         self.config: dict[bytes, bytes] = config or {}

--- a/fakeredis/_typing.py
+++ b/fakeredis/_typing.py
@@ -22,7 +22,7 @@ lib_version = metadata.version("fakeredis")
 # These are evaluated at runtime (not annotations), so they must use typing aliases rather than PEP 585 builtins to
 # remain importable on Python 3.8.
 VersionType = Tuple[int, ...]
-ServerType = Literal["redis", "dragonfly", "valkey"]
+ServerType = Literal["redis", "dragonfly", "valkey", "kividb"]
 JsonType = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
 RaiseErrorTypes: tuple[type[Exception], ...] = (redis.ResponseError, redis.AuthenticationError)
 ResponseErrorType = redis.ResponseError

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -24,13 +24,14 @@ class ServerDetails:
     redis_version: VersionType
     valkey_version: VersionType | None
     dragonfly_version: VersionType | None
+    kividb_version: VersionType | None
 
     @property
     def server_version(self) -> VersionType:
-        if self.server_type == "dragonfly":
-            # Dragonfly's own release numbering (e.g. 1.x) is unrelated to the
-            # Redis version it emulates, so FakeServer must be built with the
-            # Redis-compatible version rather than dragonfly_version.
+        if self.server_type in ("dragonfly", "kividb"):
+            # Dragonfly and KiviDB number their own releases (1.x) unrelated to the
+            # Redis version they emulate, so FakeServer must be built with the
+            # Redis-compatible version they report rather than their own.
             return self.redis_version
         elif self.server_type == "valkey":
             return self.valkey_version or self.redis_version
@@ -59,7 +60,12 @@ def real_server_details(real_server_address: tuple[str, int]) -> ServerDetails:
     try:
         client = redis.Redis(real_server_address[0], port=real_server_address[1], db=2)
         client_info = client.info()
-        server_type: ServerType = "dragonfly" if "dragonfly_version" in client_info else "redis"
+        server_type: ServerType = "redis"
+        if "dragonfly_version" in client_info:
+            server_type = "dragonfly"
+        elif "kividb_version" in client_info:
+            # KiviDB reports both redis_version and its own kividb_version, and no server_name.
+            server_type = "kividb"
         if "server_name" in client_info:
             server_type = client_info["server_name"]
         redis_version = _create_version(client_info["redis_version"]) or (7,)
@@ -67,7 +73,8 @@ def real_server_details(real_server_address: tuple[str, int]) -> ServerDetails:
         dragonfly_version = (
             _create_version(client_info["dragonfly_version"][4:]) if "dragonfly_version" in client_info else None
         )
-        return ServerDetails(server_type, redis_version, valkey_version, dragonfly_version)
+        kividb_version = _create_version(client_info["kividb_version"]) if "kividb_version" in client_info else None
+        return ServerDetails(server_type, redis_version, valkey_version, dragonfly_version, kividb_version)
     except redis.ConnectionError as e:
         pytest.exit(f"Real server is not running {e}")
         return "redis", (6,)

--- a/test/test_internals/test_init_args.py
+++ b/test/test_internals/test_init_args.py
@@ -40,6 +40,20 @@ def test_deprecated_args_no_warnings(warn_mock: mock.MagicMock):
 
 
 @pytest.mark.fake
+@pytest.mark.parametrize("server_type", ["redis", "valkey", "dragonfly", "kividb"])
+def test_supported_server_types(server_type: str):
+    r = fakeredis.FakeStrictRedis(server_type=server_type)
+    r.set("foo", "bar")
+    assert r.get("foo") == b"bar"
+
+
+@pytest.mark.fake
+def test_unsupported_server_type():
+    with pytest.raises(ValueError, match="Unsupported server type: mongo"):
+        fakeredis.FakeServer(server_type="mongo")
+
+
+@pytest.mark.fake
 class TestInitArgs:
     def test_singleton(self):
         shared_server = fakeredis.FakeServer()


### PR DESCRIPTION
Step 1 of #568 — the server type itself, no behavioural change yet.

### What this does

- `"kividb"` joins `ServerType` (`fakeredis/_typing.py`), the `FakeServer` validation list and the default
  `server_types` on `@command`, so `FakeRedis(server_type="kividb")`, `FakeServer` and `TcpFakeServer` accept it and
  serve the full command surface — identical to `redis` for now. The commands already narrowed to
  `server_types=("redis",)` / `("redis", "valkey")` stay narrowed; whether KiviDB actually has them is measured in a
  later step.
- The test harness recognises a real KiviDB on 6390.

### How the real server is detected

`INFO` on `quay.io/kividbio/kividb:latest` (kividb 1.0.4) reports:

```
# Server
redis_version:7.0.15
kividb_version:1.0.4
os:linux aarch64
tcp_port:6380
```

So, exactly like Dragonfly: a `redis_version` for the Redis version it emulates, plus its own release number under a
vendor key, and no `server_name`. Detection therefore keys off `kividb_version`, and `ServerDetails.server_version`
keeps returning the reported `redis_version` — KiviDB's own `1.0.x` numbering is unrelated to the Redis version it
emulates, which is the trap the Dragonfly version plumbing hit (every `self.version >= (7,)` check would have seen a
`1.x` server).

Note that KiviDB listens on **6380** by default, so the container is run as `-p 6390:6380`.

### Tests

`uv run pytest -m fake` — 2621 passed, 550 skipped, unchanged from master. Added a parametrized check that every
supported server type is accepted and that an unknown one still raises.

### Next steps in the stack

The suite run against a real KiviDB, then the divergences it turns up, then docs + workflow + `docker-compose.yml`
(where the changelog entry will go too, to keep it out of the way of the pending v2.38.0 entries).

<!--STACK-->
### This PR is part of a stack

Work on #568, split into reviewable steps. Each branches off the one above it, so they merge in order;
the diff shown here is only this step's own changes.

| PR | Branch | What it covers |
|---|--------|----------------|
| #569 | `kividb/01-server-type` | The `kividb` server type, and detecting a real KiviDB from `INFO` |
| #570 | `kividb/02-harness` | `test-kividb.yml`, and the suites that cannot apply to KiviDB |
| #571 | `kividb/03-command-surface` | Which commands KiviDB has, and its bare unknown-command error |
| #572 | `kividb/04-errors` | The permissive argument parsing of its sorted set commands |
| #573 | `kividb/05-type-checks` | The type checks it skips, the one it adds, and two crash fixes |

More steps follow: the remaining behavioural divergences the measurement in #570 turned up, then
`docs/kividb-support.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
