### PR TITLE
feat(kividb): match KiviDB's command surface

### DIFF
--- a/fakeredis/_basefakesocket.py
+++ b/fakeredis/_basefakesocket.py
@@ -267,11 +267,13 @@ class BaseFakeSocket:
     def _unknown_command(self, command: str, args: str | None = None) -> SimpleError:
         """Build the server's "unknown command" error.
 
-        Dragonfly uses its own wording and never echoes the arguments back, so `args` is only appended for the
-        Redis/Valkey format.
+        Dragonfly uses its own wording and never echoes the arguments back, and KiviDB names nothing at all, so
+        `args` is only appended for the Redis/Valkey format.
         """
         if self._server.server_type == "dragonfly":
             return SimpleError(msgs.DRAGONFLY_UNKNOWN_COMMAND_MSG.format(command.upper()))
+        if self._server.server_type == "kividb":
+            return SimpleError(msgs.KIVIDB_UNKNOWN_COMMAND_MSG)
         msg = msgs.UNKNOWN_COMMAND_MSG.format(command)
         if args is not None:
             msg += f"'{args}' "

--- a/fakeredis/_msgs.py
+++ b/fakeredis/_msgs.py
@@ -43,6 +43,10 @@ WRONG_ARGS_MSG6 = "ERR wrong number of arguments for '{}' command"
 UNKNOWN_COMMAND_MSG = "ERR unknown command '{}', with args beginning with: "
 # Dragonfly reports unknown commands in its own format, without echoing the arguments back.
 DRAGONFLY_UNKNOWN_COMMAND_MSG = "ERR unknown command `{}`"
+# KiviDB names neither the command nor its arguments.
+KIVIDB_UNKNOWN_COMMAND_MSG = "ERR unknown command"
+# KiviDB's SCRIPT container reports an unknown subcommand in lower case, unlike its other containers.
+KIVIDB_UNKNOWN_SCRIPT_SUBCOMMAND_MSG = "ERR unknown subcommand '{}' for SCRIPT"
 # Raised by dragonfly for an absolute expiry deadline beyond DRAGONFLY_MAX_EXPIRE_SECONDS.
 EXPIRY_OUT_OF_RANGE_MSG = "ERR expiry is out of range"
 # Dragonfly checks the expiry option pairs separately, and accepts NX together with GT/LT.

--- a/fakeredis/commands_mixins/generic_mixin.py
+++ b/fakeredis/commands_mixins/generic_mixin.py
@@ -409,7 +409,8 @@ class GenericCommandsMixin(CommandsMixinBase):
     def type_cmd(self, key: CommandItem) -> SimpleString:
         return self._key_value_type(key)
 
-    @command(name="UNLINK", fixed=(Key(),), repeat=(Key(),))
+    # KiviDB has no UNLINK at all; DEL is the only way to remove a key there.
+    @command(name="UNLINK", fixed=(Key(),), repeat=(Key(),), server_types=("redis", "valkey", "dragonfly"))
     def unlink(self, *keys: CommandItem) -> int:
         return delete_keys(*keys)
 

--- a/fakeredis/commands_mixins/hash_mixin.py
+++ b/fakeredis/commands_mixins/hash_mixin.py
@@ -257,30 +257,34 @@ class HashCommandsMixin(CommandsMixinBase):
         return res
 
     @command(
-        name="HEXPIRETIME", fixed=(Key(Hash),), repeat=(bytes,), flags=msgs.FLAG_DO_NOT_CREATE, server_types=("redis",)
+        name="HEXPIRETIME",
+        fixed=(Key(Hash),),
+        repeat=(bytes,),
+        flags=msgs.FLAG_DO_NOT_CREATE,
+        server_types=("redis", "kividb"),
     )
     def hexpiretime(self, key: CommandItem, *args: bytes) -> list[int]:
         res = self._get_expireat(b"HEXPIRETIME", key, *args)
         return [(i // 1000 if i > 0 else i) for i in res]
 
-    @command(name="HPEXPIRETIME", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis",))
+    @command(name="HPEXPIRETIME", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis", "kividb"))
     def hpexpiretime(self, key: CommandItem, *args: bytes) -> list[int]:
         res = self._get_expireat(b"HPEXPIRETIME", key, *args)
         return res
 
-    @command(name="HTTL", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis",))
+    @command(name="HTTL", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis", "kividb"))
     def httl(self, key: CommandItem, *args: bytes) -> list[int]:
         curr_expireat_ms = self._get_expireat(b"HTTL", key, *args)
         curr_time_ms = current_time()
         return [((i - curr_time_ms) // 1000) if i > 0 else i for i in curr_expireat_ms]
 
-    @command(name="HPTTL", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis",))
+    @command(name="HPTTL", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis", "kividb"))
     def hpttl(self, key: CommandItem, *args: bytes) -> list[int]:
         curr_expireat_ms = self._get_expireat(b"HPTTL", key, *args)
         curr_time_ms = current_time()
         return [(i - curr_time_ms) if i > 0 else i for i in curr_expireat_ms]
 
-    @command(name="HGETDEL", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis",))
+    @command(name="HGETDEL", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis", "kividb"))
     def hgetdel(self, key: CommandItem, *args: bytes) -> list[Any]:
         fields = _get_fields(args, command="hgetdel")
         hash_val: Hash = key.value
@@ -291,7 +295,7 @@ class HashCommandsMixin(CommandsMixinBase):
         self.add_subkey_event(b"hdel", key.key, deleted_fields)
         return res
 
-    @command(name="HGETEX", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis",))
+    @command(name="HGETEX", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis", "kividb"))
     def hgetex(self, key: CommandItem, *args: bytes) -> Any:
         (ex, px, exat, pxat, persist), left_args = extract_args(
             args,
@@ -324,6 +328,8 @@ class HashCommandsMixin(CommandsMixinBase):
         self.add_subkey_event(b"hdel", key.key, deleted_fields)
         return res
 
+    # KiviDB has HSETEX, but in the `HSETEX key seconds FIELDS numfields field value` form rather than
+    # Redis' `HSETEX key [EX seconds] FVS numfields field value`, so it stays off KiviDB's surface.
     @command(name="HSETEX", fixed=(Key(Hash),), repeat=(bytes,), server_types=("redis",))
     def hsetex(self, key: CommandItem, *args: bytes) -> Any:
         (ex, px, exat, pxat, keepttl, fnx, fxx), left_args = extract_args(

--- a/fakeredis/commands_mixins/scripting_mixin.py
+++ b/fakeredis/commands_mixins/scripting_mixin.py
@@ -414,6 +414,9 @@ class ScriptingCommandsMixin(CommandsMixinBase):
     def script_help(self, *args: bytes) -> list[bytes]:
         if self.server_type == "dragonfly":
             return [s.encode() for s in DRAGONFLY_SCRIPT_HELP]
+        if self.server_type == "kividb":
+            # KiviDB's SCRIPT has no HELP subcommand.
+            raise SimpleError(msgs.KIVIDB_UNKNOWN_SCRIPT_SUBCOMMAND_MSG.format("help"))
         help_strings = [
             "SCRIPT <subcommand> [<arg> [value] [opt] ...]. Subcommands are:",
             "DEBUG (YES|SYNC|NO)",

--- a/fakeredis/commands_mixins/streams_mixin.py
+++ b/fakeredis/commands_mixins/streams_mixin.py
@@ -323,7 +323,7 @@ class StreamsCommandsMixin(CommandsMixinBase):
             res.append([msg.encode() for msg in msgs_removed])
         return res
 
-    @command(name="XDELEX", fixed=(Key(XStream),), repeat=(bytes,), server_types=("redis",))
+    @command(name="XDELEX", fixed=(Key(XStream),), repeat=(bytes,), server_types=("redis", "kividb"))
     def xdelex(self, key: CommandItem, *args: bytes) -> list[int]:
         """XDELEX key [KEEPREF | DELREF | ACKED] IDS numids id [id ...]"""
         mode, ids = self._parse_xdelex_args(args, "XDELEX")
@@ -333,6 +333,8 @@ class StreamsCommandsMixin(CommandsMixinBase):
         key.updated()
         return res
 
+    # KiviDB has XACKDEL, but shaped like XACK - `XACKDEL key group id [id ...]`, with no ref-policy
+    # and no IDS count - so the Redis form below would answer where the real server errors.
     @command(name="XACKDEL", fixed=(Key(XStream), bytes), repeat=(bytes,), server_types=("redis",))
     def xackdel(self, key: CommandItem, group_name: bytes, *args: bytes) -> list[int]:
         """XACKDEL key group [KEEPREF | DELREF | ACKED] IDS numids id [id ...]"""
@@ -366,10 +368,11 @@ class StreamsCommandsMixin(CommandsMixinBase):
         ids = list(args[i : i + num_ids])
         return mode, ids
 
-    @command(name="XNACK", fixed=(Key(XStream), bytes), repeat=(bytes,), server_types=("redis",))
+    @command(name="XNACK", fixed=(Key(XStream), bytes), repeat=(bytes,), server_types=("redis", "kividb"))
     def xnack(self, key: CommandItem, group_name: bytes, *args: bytes) -> int:
         """XNACK key group <SILENT | FAIL | FATAL> IDS numids id [id ...] [RETRYCOUNT count] [FORCE]"""
-        if self.version < (8, 8):
+        # As for INCREX, KiviDB has XNACK despite reporting redis_version 7.0.15.
+        if self.version < (8, 8) and self.server_type != "kividb":
             raise SimpleError(msgs.UNKNOWN_COMMAND_MSG.format("XNACK"))
         if len(args) < 3:
             raise SimpleError(msgs.WRONG_ARGS_MSG6.format("XNACK"))

--- a/fakeredis/commands_mixins/string_mixin.py
+++ b/fakeredis/commands_mixins/string_mixin.py
@@ -149,9 +149,11 @@ class StringCommandsMixin(CommandsMixinBase, ABC):
             return Float.decode(raw, decode_error=msgs.INCREX_BOUND_NOT_FLOAT_MSG.format(name))
         return Int.decode(raw, decode_error=msgs.INCREX_BOUND_NOT_INTEGER_MSG.format(name))
 
-    @command(name="INCREX", fixed=(Key(bytes),), repeat=(bytes,), server_types=("redis",))
+    @command(name="INCREX", fixed=(Key(bytes),), repeat=(bytes,), server_types=("redis", "kividb"))
     def increx(self, key: CommandItem, *args: bytes) -> list[Any]:
-        if self.version < (8, 8):
+        # KiviDB reports redis_version 7.0.15 but ships INCREX, so its support is keyed off the
+        # server type rather than the version it claims.
+        if self.version < (8, 8) and self.server_type != "kividb":
             raise SimpleError(msgs.UNKNOWN_COMMAND_MSG.format("INCREX"))
         (byfloat, byint, saturate, lbound, ubound, ex, px, exat, pxat, persist, enx), _ = extract_args(
             args,
@@ -384,7 +386,7 @@ class StringCommandsMixin(CommandsMixinBase, ABC):
             key.expireat = None if expire_time is None else int(expire_time)
         return key.get(None)
 
-    @command(fixed=(Key(bytes), Key(bytes)), repeat=(bytes,), server_types=("redis", "valkey"))
+    @command(fixed=(Key(bytes), Key(bytes)), repeat=(bytes,), server_types=("redis", "valkey", "kividb"))
     def lcs(self, k1: CommandItem, k2: CommandItem, *args: bytes) -> bytes | int | dict[bytes, Any]:
         s1 = k1.value or b""
         s2 = k2.value or b""

--- a/test/test_kividb/test_command_surface.py
+++ b/test/test_kividb/test_command_surface.py
@@ -1,0 +1,101 @@
+"""The commands KiviDB has, and the ones it does not.
+
+KiviDB reports `redis_version:7.0.15` but its command surface is not Redis 7.0's: it ships the
+hash-field TTL family (Redis 7.4), `INCREX` and the `XDELEX`/`XACKDEL`/`XNACK` family (Redis 8.8),
+and lacks `UNLINK` and `SCRIPT HELP`, which Redis has had since 4.0 and 5.0. Support is therefore
+keyed off the server type rather than off the version it claims.
+"""
+
+from __future__ import annotations
+
+import pytest
+import redis
+
+import fakeredis
+from fakeredis._typing import ClientType
+from test.testtools import raw_command
+
+pytestmark = []
+pytestmark.extend(
+    [
+        pytest.mark.unsupported_server_types("redis", "valkey", "dragonfly"),
+    ]
+)
+
+
+def test_lcs(r: ClientType):
+    r.set("key1", "ohmytext")
+    r.set("key2", "mynewtext")
+    assert raw_command(r, "lcs", "key1", "key2") == b"mytext"
+
+
+def test_hash_field_expiry_commands(r: ClientType):
+    r.hset("h", mapping={"f1": "v1", "f2": "v2"})
+    assert raw_command(r, "hexpire", "h", 100, "fields", 1, "f1") == [1]
+    ttls = raw_command(r, "httl", "h", "fields", 2, "f1", "f2")
+    assert ttls[0] in (99, 100) and ttls[1] == -1
+    assert raw_command(r, "hpttl", "h", "fields", 1, "f1")[0] > 99000
+    assert raw_command(r, "hexpiretime", "h", "fields", 1, "f2") == [-1]
+    assert raw_command(r, "hpexpiretime", "h", "fields", 1, "f2") == [-1]
+    assert raw_command(r, "hgetex", "h", "fields", 1, "f2") == [b"v2"]
+    assert raw_command(r, "hgetdel", "h", "fields", 1, "f2") == [b"v2"]
+    assert r.hget("h", "f2") is None
+
+
+def test_increx(r: ClientType):
+    assert raw_command(r, "increx", "counter") == [1, 1]
+    assert raw_command(r, "increx", "counter", "ex", 100) == [2, 1]
+    assert r.ttl("counter") == 100
+
+
+def test_xdelex(r: ClientType):
+    entry_id = r.xadd("stream", {"f": "v"})
+    assert raw_command(r, "xdelex", "stream", "ids", 1, entry_id) == [1]
+    assert raw_command(r, "xdelex", "stream", "keepref", "ids", 1, entry_id) == [-1]
+
+
+def test_xnack(r: ClientType):
+    entry_id = r.xadd("stream", {"f": "v"})
+    r.xgroup_create("stream", "group", id="0")
+    r.xreadgroup("group", "consumer", {"stream": ">"})
+    assert raw_command(r, "xnack", "stream", "group", "fail", "ids", 1, entry_id) == 1
+
+
+def test_no_unlink(r: ClientType):
+    r.set("key", "value")
+    with pytest.raises(redis.ResponseError, match="unknown command"):
+        raw_command(r, "unlink", "key")
+    assert r.get("key") == b"value"
+
+
+def test_no_script_help(r: ClientType):
+    with pytest.raises(redis.ResponseError, match="unknown subcommand 'help' for SCRIPT"):
+        raw_command(r, "script", "help")
+
+
+def test_unknown_command_names_nothing(r: ClientType):
+    """Redis echoes the command and its arguments back; KiviDB reports neither."""
+    with pytest.raises(redis.ResponseError) as ctx:
+        raw_command(r, "nosuchcommand", "key", "value")
+    assert str(ctx.value) == "unknown command"
+
+
+@pytest.mark.fake
+@pytest.mark.parametrize(
+    "args",
+    [
+        # KiviDB takes `HSETEX key seconds FIELDS numfields field value`, not Redis' FVS form.
+        ("hsetex", "h", 100, "fields", 1, "f", "v"),
+        # KiviDB's XACKDEL is shaped like XACK: `XACKDEL key group id [id ...]`.
+        ("xackdel", "stream", "group", "ids", 1, "1-1"),
+    ],
+)
+def test_commands_kividb_spells_differently_are_refused(args):
+    """Both commands exist on KiviDB, in an argument form fakeredis does not implement.
+
+    Refusing them keeps a script that uses the Redis form from passing here and failing against a
+    real KiviDB; emulating KiviDB's own form would be the better answer.
+    """
+    r = fakeredis.FakeStrictRedis(server_type="kividb")
+    with pytest.raises(redis.ResponseError, match="unknown command"):
+        raw_command(r, *args)

--- a/test/test_mixins/test_generic_commands.py
+++ b/test/test_mixins/test_generic_commands.py
@@ -300,6 +300,7 @@ def test_type(r: ClientType):
     assert r.type("none_key") == b"none"
 
 
+@pytest.mark.unsupported_server_types("kividb")  # KiviDB has no UNLINK
 def test_unlink(r: ClientType):
     r.set("foo", "bar")
     r.unlink("foo")


### PR DESCRIPTION
Step 3 of #568 — which commands `server_type="kividb"` serves, and what it says about the ones it does not.

### The finding this rests on

KiviDB's `redis_version` is not a proxy for its command surface. It reports **7.0.15**, and yet:

| command | in Redis since | on KiviDB |
|---|---|---|
| `HTTL`, `HPTTL`, `HEXPIRETIME`, `HPEXPIRETIME`, `HGETEX`, `HGETDEL` | 7.4 | ✅ |
| `INCREX`, `XNACK` | 8.8 | ✅ |
| `LCS` | 7.0 | ✅ |
| `UNLINK` | 4.0 | ❌ unknown command |
| `SCRIPT HELP` | 5.0 | ❌ `unknown subcommand 'help' for SCRIPT` |

So support keys off the server type, not off the version — including the two `self.version < (8, 8)` gates in
`INCREX` and `XNACK`, which now read `and self.server_type != "kividb"`. That is the idiom the Dragonfly work
settled on: gate on the server type, not on the version a server claims.

Every line of the table was probed against a real `quay.io/kividbio/kividb:v1.0.4-lua`, and the whole surface was
diffed command by command: fakeredis's registry now matches what the container answers, with the two documented
exceptions below.

### Left refused on purpose

`HSETEX` and `XACKDEL` both exist on KiviDB, in argument forms fakeredis does not implement:

```
HSETEX key seconds FIELDS numfields field value      # Redis: HSETEX key [EX s] FVS numfields field value
XACKDEL key group id [id ...]                        # Redis: XACKDEL key group [KEEPREF|DELREF|ACKED] IDS n id...
```

Serving the Redis form would answer where a real KiviDB errors — a script that passes here and fails there is
worse than one that fails in both places — so they stay off the surface until KiviDB's own form is emulated.
`test_commands_kividb_spells_differently_are_refused` pins that decision down so it is a choice, not a gap.

### Unknown commands

KiviDB answers a bare `ERR unknown command` — no command name, no arguments — where Redis echoes both back and
Dragonfly names the command in backticks. `_unknown_command` grows a third branch.

### Tests

New `test/test_kividb/`, in the shape of `test/test_dragonfly/`: 34 tests, passing against both a fake KiviDB and
the real container. It is in the `test-kividb.yml` matrix.

Full suite against a real **redis:8.4.0**: 5011 passed, 2 failed — `test_pubsub_shardnumsub[Strict3]`, a
subscription leak that fails on master too, and one hypothesis flake that passes on re-run. No regression.

<!--STACK-->
### This PR is part of a stack

Work on #568, split into reviewable steps. Each branches off the one above it, so they merge in order;
the diff shown here is only this step's own changes.

| PR | Branch | What it covers |
|---|--------|----------------|
| #569 | `kividb/01-server-type` | The `kividb` server type, and detecting a real KiviDB from `INFO` |
| #570 | `kividb/02-harness` | `test-kividb.yml`, and the suites that cannot apply to KiviDB |
| #571 | `kividb/03-command-surface` | Which commands KiviDB has, and its bare unknown-command error |
| #572 | `kividb/04-errors` | The permissive argument parsing of its sorted set commands |
| #573 | `kividb/05-type-checks` | The type checks it skips, the one it adds, and two crash fixes |

More steps follow: the remaining behavioural divergences the measurement in #570 turned up, then
`docs/kividb-support.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
