### PR TITLE
feat(kividb): follow its type checks, and fix two crashes on the way

### DIFF
--- a/fakeredis/_commands.py
+++ b/fakeredis/_commands.py
@@ -27,9 +27,17 @@ class Key:
 
     UNSPECIFIED = object()
 
-    def __init__(self, type_: type[Any] | None = None, missing_return: Any = UNSPECIFIED) -> None:
+    def __init__(
+        self,
+        type_: type[Any] | None = None,
+        missing_return: Any = UNSPECIFIED,
+        empty_on_wrongtype: Collection[ServerType] = (),
+    ) -> None:
         self.type_ = type_
         self.missing_return = missing_return
+        # Server types that read a key of the wrong type as an empty one here, rather than answering
+        # WRONGTYPE. KiviDB does that for the multi-key set operations.
+        self.empty_on_wrongtype = empty_on_wrongtype
 
 
 class Item:
@@ -375,7 +383,9 @@ class Signature:
                 item = db.get(arg)
                 default = None
                 if type_.type_ is not None and item is not None and type(item.value) is not type_.type_:
-                    raise SimpleError(msgs.WRONGTYPE_MSG)
+                    if server_type not in type_.empty_on_wrongtype:
+                        raise SimpleError(msgs.WRONGTYPE_MSG)
+                    item = None
                 if (
                     msgs.FLAG_DO_NOT_CREATE not in self.flags
                     and type_.type_ is not None

--- a/fakeredis/commands_mixins/list_mixin.py
+++ b/fakeredis/commands_mixins/list_mixin.py
@@ -44,11 +44,17 @@ def _list_pop(get_slice: Callable[[int], slice], key: CommandItem, *args: bytes)
 
 
 class ListCommandsMixin(CommandsMixinBase):
-    def _bpop_pass(self, keys: list[bytes], op: Callable[[list[bytes]], bytes], first_pass: bool) -> list[bytes] | None:
+    def _bpop_pass(
+        self,
+        keys: list[bytes],
+        op: Callable[[list[bytes]], bytes],
+        first_pass: bool,
+        check_type: bool = True,
+    ) -> list[bytes] | None:
         for key in keys:
             item = CommandItem(key, self._db, item=self._db.get(key), default=[])
             if not isinstance(item.value, list):
-                if first_pass:
+                if first_pass and check_type:
                     raise SimpleError(msgs.WRONGTYPE_MSG)
                 else:
                     continue
@@ -59,10 +65,14 @@ class ListCommandsMixin(CommandsMixinBase):
                 return [key, ret]
         return None
 
-    def _bpop(self, args: Any, op: Callable[[list[bytes]], bytes]) -> Any:
+    def _bpop(self, args: Any, op: Callable[[list[bytes]], bytes], check_type: bool = True) -> Any:
         keys = args[:-1]
         timeout = Timeout.decode(args[-1])
-        return self._blocking(timeout, functools.partial(self._bpop_pass, keys, op), self._empty_blocking_reply)
+        return self._blocking(
+            timeout,
+            functools.partial(self._bpop_pass, keys, op, check_type=check_type),
+            self._empty_blocking_reply,
+        )
 
     @command((bytes, bytes), (bytes,), flags=msgs.FLAG_NO_SCRIPT)
     def blpop(self, *args: bytes) -> Any:
@@ -70,12 +80,15 @@ class ListCommandsMixin(CommandsMixinBase):
 
     @command((bytes, bytes), (bytes,), flags=msgs.FLAG_NO_SCRIPT)
     def brpop(self, *args: bytes) -> Any:
-        return self._bpop(args, lambda lst: lst.pop())
+        # KiviDB checks the key's type in BLPOP but not in BRPOP, where a key of the wrong type is
+        # simply passed over -- so a BRPOP naming only such a key blocks, and then answers nil.
+        return self._bpop(args, lambda lst: lst.pop(), check_type=self.server_type != "kividb")
 
     def _brpoplpush_pass(self, source: bytes, destination: bytes, first_pass: bool) -> Any:
         src = CommandItem(source, self._db, item=self._db.get(source), default=[])
         if not isinstance(src.value, list):
-            if first_pass:
+            # As for BRPOP, KiviDB passes over a source of the wrong type instead of reporting it.
+            if first_pass and self.server_type != "kividb":
                 raise SimpleError(msgs.WRONGTYPE_MSG)
             else:
                 return None
@@ -170,6 +183,8 @@ class ListCommandsMixin(CommandsMixinBase):
 
         for key in keys:
             item = CommandItem(key, self._db, item=self._db.get(key), default=[])
+            if self.server_type == "kividb" and item and not isinstance(item.value, list):
+                continue  # KiviDB's LMPOP and BLMPOP pass over a key of the wrong type
             res = _list_pop_count(op, item, count)
             if res:
                 return [key, res]

--- a/fakeredis/commands_mixins/set_mixin.py
+++ b/fakeredis/commands_mixins/set_mixin.py
@@ -7,21 +7,34 @@ from typing import Any, Callable
 from fakeredis import _msgs as msgs
 from fakeredis._commands import CommandItem, Int, Key, command
 from fakeredis._helpers import OK, SimpleError, SimpleString, casematch
+from fakeredis._typing import ServerType
 from fakeredis.commands_mixins._mixin_base import CommandsMixinBase
 from fakeredis.model import ExpiringMembersSet
 
+# An input set of SDIFF/SINTER/SUNION and their STORE forms. KiviDB reads one of the wrong type as empty
+# rather than answering WRONGTYPE.
+_LAX_SET_TYPES: tuple[ServerType, ...] = ("kividb",)
+_SET_INPUT = Key(ExpiringMembersSet, empty_on_wrongtype=_LAX_SET_TYPES)
 
-def _calc_setop(op: Callable[..., Any], stop_if_missing: bool, key: CommandItem, *keys: CommandItem) -> Any:
+
+def _calc_setop(
+    op: Callable[..., Any], stop_if_missing: bool, key: CommandItem, *keys: CommandItem, lax_types: bool = False
+) -> Any:
+    """`lax_types` reads an input key of the wrong type as an empty set, which is what KiviDB does."""
     if stop_if_missing and not key.value:
         return set()
     value = key.value
     if not isinstance(value, ExpiringMembersSet):
-        raise SimpleError(msgs.WRONGTYPE_MSG)
+        if not lax_types:
+            raise SimpleError(msgs.WRONGTYPE_MSG)
+        return set()
     ans = value.copy()
     for other in keys:
         value = other.value if other.value is not None else ExpiringMembersSet()
         if not isinstance(value, ExpiringMembersSet):
-            raise SimpleError(msgs.WRONGTYPE_MSG)
+            if not lax_types:
+                raise SimpleError(msgs.WRONGTYPE_MSG)
+            value = ExpiringMembersSet()
         if stop_if_missing and not value:
             return set()
         ans = op(ans, value)
@@ -29,14 +42,19 @@ def _calc_setop(op: Callable[..., Any], stop_if_missing: bool, key: CommandItem,
 
 
 def _setop(
-    op: Callable[..., Any], stop_if_missing: bool, dst: CommandItem | None, key: CommandItem, *keys: CommandItem
+    op: Callable[..., Any],
+    stop_if_missing: bool,
+    dst: CommandItem | None,
+    key: CommandItem,
+    *keys: CommandItem,
+    lax_types: bool = False,
 ) -> Any:
     """Apply one of SINTER[STORE], SUNION[STORE], SDIFF[STORE].
 
     If `stop_if_missing`, the output will be made an empty set as soon as an empty input set is encountered (use for
     SINTER[STORE]). May assume that `key` is a set (or empty), but `keys` could be anything.
     """
-    ans = _calc_setop(op, stop_if_missing, key, *keys)
+    ans = _calc_setop(op, stop_if_missing, key, *keys, lax_types=lax_types)
     if dst is None:
         return list(ans)
     else:
@@ -46,6 +64,11 @@ def _setop(
 
 class SetCommandsMixin(CommandsMixinBase):
     _scan: Callable[[Sequence[bytes], int, bytes], list[bytes | list[bytes]]]
+
+    @property
+    def _lax_set_types(self) -> bool:
+        """KiviDB's multi-key set operations read a key of the wrong type as an empty set."""
+        return self.server_type == "kividb"
 
     @command((Key(ExpiringMembersSet), bytes), (bytes,))
     def sadd(self, key: CommandItem, *members: bytes) -> int:
@@ -58,15 +81,15 @@ class SetCommandsMixin(CommandsMixinBase):
     def scard(self, key: CommandItem) -> int:
         return len(key.value)
 
-    @command((Key(ExpiringMembersSet),), (Key(ExpiringMembersSet),))
+    @command((_SET_INPUT,), (_SET_INPUT,))
     def sdiff(self, *keys: CommandItem) -> Any:
-        return _setop(lambda a, b: a - b, False, None, *keys)
+        return _setop(lambda a, b: a - b, False, None, *keys, lax_types=self._lax_set_types)
 
-    @command((Key(), Key(ExpiringMembersSet)), (Key(ExpiringMembersSet),))
+    @command((Key(), _SET_INPUT), (_SET_INPUT,))
     def sdiffstore(self, dst: CommandItem, *keys: CommandItem) -> Any:
-        return _setop(lambda a, b: a - b, False, dst, *keys)
+        return _setop(lambda a, b: a - b, False, dst, *keys, lax_types=self._lax_set_types)
 
-    @command((Key(ExpiringMembersSet),), (Key(ExpiringMembersSet),))
+    @command((_SET_INPUT,), (_SET_INPUT,))
     def sinter(self, *keys: CommandItem) -> Any:
         res = _setop(lambda a, b: a & b, True, None, *keys)
         return res
@@ -93,12 +116,12 @@ class SetCommandsMixin(CommandsMixinBase):
             raise SimpleError(msgs.SYNTAX_ERROR_MSG)
         keys = [CommandItem(args[i], self._db, item=self._db.get(args[i])) for i in range(numkeys)]
 
-        res = _setop(lambda a, b: a & b, False, None, *keys)
+        res = _setop(lambda a, b: a & b, False, None, *keys, lax_types=self._lax_set_types)
         return len(res) if limit == 0 else min(limit, len(res))
 
-    @command((Key(), Key(ExpiringMembersSet)), (Key(ExpiringMembersSet),))
+    @command((Key(), _SET_INPUT), (_SET_INPUT,))
     def sinterstore(self, dst: CommandItem, *keys: CommandItem) -> Any:
-        return _setop(lambda a, b: a & b, True, dst, *keys)
+        return _setop(lambda a, b: a & b, True, dst, *keys, lax_types=self._lax_set_types)
 
     @command((Key(ExpiringMembersSet), bytes))
     def sismember(self, key: CommandItem, member: bytes) -> int:
@@ -180,13 +203,13 @@ class SetCommandsMixin(CommandsMixinBase):
     def sscan(self, key: CommandItem, cursor: int, *args: bytes) -> Any:
         return self._scan(key.value, cursor, *args)
 
-    @command((Key(ExpiringMembersSet),), (Key(ExpiringMembersSet),))
+    @command((_SET_INPUT,), (_SET_INPUT,))
     def sunion(self, *keys: CommandItem) -> Any:
-        return _setop(lambda a, b: a | b, False, None, *keys)
+        return _setop(lambda a, b: a | b, False, None, *keys, lax_types=self._lax_set_types)
 
-    @command((Key(), Key(ExpiringMembersSet)), (Key(ExpiringMembersSet),))
+    @command((Key(), _SET_INPUT), (_SET_INPUT,))
     def sunionstore(self, dst: CommandItem, *keys: CommandItem) -> Any:
-        return _setop(lambda a, b: a | b, False, dst, *keys)
+        return _setop(lambda a, b: a | b, False, dst, *keys, lax_types=self._lax_set_types)
 
     # Hyperloglog commands
     # These are not quite the same as the real redis ones, which are approximate and store the results in a string.

--- a/fakeredis/commands_mixins/sortedset_mixin.py
+++ b/fakeredis/commands_mixins/sortedset_mixin.py
@@ -123,6 +123,11 @@ class SortedSetCommandsMixin(CommandsMixinBase):
     def _bzpop(self, keys: list[bytes], reverse: bool, first_pass: bool) -> list[bytes | list[bytes]] | None:
         for key in keys:
             item = CommandItem(key, self._db, item=self._db.get(key), default=[])
+            if item and not isinstance(item.value, ZSet):
+                # KiviDB passes over a key of the wrong type here, as it does in BRPOP.
+                if self.server_type == "kividb":
+                    continue
+                raise SimpleError(msgs.WRONGTYPE_MSG)
             temp_res = self._zpop(item, 1, reverse, flatten_list=False)
             if temp_res:
                 item.writeback()  # remove the key if the set is now empty
@@ -589,8 +594,10 @@ class SortedSetCommandsMixin(CommandsMixinBase):
                 raise SimpleError(msgs.SYNTAX_ERROR_MSG)
 
         # Redis reads a plain set as a sorted set scoring every member 1. Dragonfly does that too, except in
-        # ZDIFF/ZDIFFSTORE, which only accept sorted sets.
-        zsets_only = self.server_type == "dragonfly" and func in {"ZDIFF", "ZDIFFSTORE"}
+        # ZDIFF/ZDIFFSTORE, which only accept sorted sets; KiviDB never does it, in any of these commands.
+        zsets_only = self.server_type == "kividb" or (
+            self.server_type == "dragonfly" and func in {"ZDIFF", "ZDIFFSTORE"}
+        )
         sets = []
         for i in range(numkeys):
             item = CommandItem(args[i], self._db, item=self._db.get(args[i]), default=ZSet())
@@ -735,9 +742,15 @@ class SortedSetCommandsMixin(CommandsMixinBase):
             res = [list(item) for item in res]
         return res
 
-    def _zmpop(self, keys: Sequence[bytes], count: int, reverse: bool, first_pass: bool) -> list[Any] | None:
+    def _zmpop(
+        self, keys: Sequence[bytes], count: int, reverse: bool, first_pass: bool, check_type: bool = True
+    ) -> list[Any] | None:
         for key in keys:
             item = CommandItem(key, self._db, item=self._db.get(key), default=[])
+            if item and not isinstance(item.value, ZSet):
+                if check_type:
+                    raise SimpleError(msgs.WRONGTYPE_MSG)
+                continue
             res = self._zpop(item, count, reverse, flatten_list=False)
             if res:
                 item.writeback()  # remove the key if the set is now empty
@@ -757,5 +770,6 @@ class SortedSetCommandsMixin(CommandsMixinBase):
         keys, count, reverse = parse_mpop_args("bzmpop", numkeys, args, ("max", "min"), self.server_type)
         return self._blocking(  # type: ignore[no-any-return]
             timeout,
-            functools.partial(self._zmpop, keys, count, reverse),
+            # KiviDB checks the key's type in ZMPOP but not in BZMPOP.
+            functools.partial(self._zmpop, keys, count, reverse, check_type=self.server_type != "kividb"),
         )

--- a/fakeredis/commands_mixins/streams_mixin.py
+++ b/fakeredis/commands_mixins/streams_mixin.py
@@ -23,6 +23,10 @@ class StreamsCommandsMixin(CommandsMixinBase):
         elements = left_args[1:]
         if not elements or len(elements) % 2 != 0:
             raise SimpleError(msgs.WRONG_ARGS_MSG6.format("XADD"))
+        # XADD takes an untyped Key so that NOMKSTREAM can tell a missing key from an empty stream,
+        # which leaves the type check to be made here, once the arity is known to be good.
+        if key.value is not None and not isinstance(key.value, XStream):
+            raise SimpleError(msgs.WRONGTYPE_MSG)
         stream = key.value if key.value is not None else XStream()
         if self.version < (7,) and entry_key != b"*" and not StreamRangeTest.valid_key(entry_key):
             raise SimpleError(msgs.XADD_INVALID_ID)

--- a/test/test_kividb/test_type_checks.py
+++ b/test/test_kividb/test_type_checks.py
@@ -1,0 +1,128 @@
+"""The type checks KiviDB does not make, and the one it makes that redis does not.
+
+Redis answers WRONGTYPE for any key whose type a command cannot use. KiviDB reads a wrongly typed
+key as an empty one in its multi-key set operations, and passes over one in some -- not all -- of its
+blocking pops. It is stricter in the other direction for the sorted set aggregates, which refuse a
+plain set that redis would read as a sorted set scoring every member 1.
+
+The redis-flavoured versions of these tests are marked
+`@pytest.mark.unsupported_server_types("kividb")` in `test/test_mixins`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fakeredis._typing import ClientType
+from test.testtools import raw_command
+
+pytestmark = []
+pytestmark.extend(
+    [
+        pytest.mark.unsupported_server_types("redis", "valkey", "dragonfly"),
+    ]
+)
+
+WRONGTYPE = "WRONGTYPE Operation against a key holding the wrong kind of value"
+
+
+@pytest.fixture
+def mixed(r: ClientType) -> ClientType:
+    """A string, a list, a set and a sorted set, so every command has a wrong type to be given."""
+    r.set("str", "v")
+    r.rpush("list", "a", "b")
+    r.sadd("set", "m")
+    r.zadd("zset", {"m": 1})
+    return r
+
+
+def test_multi_key_set_reads_take_a_wrong_type_as_empty(mixed: ClientType):
+    assert raw_command(mixed, "sdiff", "str", "set") == []
+    assert raw_command(mixed, "sdiff", "set", "str") == [b"m"]
+    assert raw_command(mixed, "sinter", "str", "set") == []
+    assert raw_command(mixed, "sunion", "str", "set") == [b"m"]
+    assert raw_command(mixed, "sintercard", 2, "str", "set") == 0
+    # A sorted set is just as wrong a type here as a string is.
+    assert raw_command(mixed, "sunion", "zset", "set") == [b"m"]
+
+
+def test_multi_key_set_stores_take_a_wrong_type_as_empty(mixed: ClientType):
+    assert raw_command(mixed, "sdiffstore", "dest", "str", "set") == 0
+    assert raw_command(mixed, "sinterstore", "dest", "str", "set") == 0
+    assert raw_command(mixed, "sunionstore", "dest", "str", "set") == 1
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("smembers", "str"),
+        ("scard", "str"),
+        ("sismember", "str", "m"),
+        ("sadd", "str", "m"),
+        ("srem", "str", "m"),
+        ("spop", "str"),
+        ("smove", "str", "set", "m"),
+        ("smove", "set", "str", "m"),
+    ],
+)
+def test_single_key_set_commands_still_check(mixed: ClientType, args: tuple):
+    with pytest.raises(Exception, match=WRONGTYPE):
+        raw_command(mixed, *args)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("brpop", "str", 0.1),
+        ("brpoplpush", "str", "list", 0.1),
+        ("bzpopmin", "str", 0.1),
+        ("bzpopmax", "str", 0.1),
+        ("bzmpop", 0.1, 1, "str", "min"),
+        ("blmpop", 0.1, 1, "str", "left"),
+        ("lmpop", 1, "str", "left"),
+    ],
+)
+def test_pops_that_pass_over_a_wrong_type(mixed: ClientType, args: tuple):
+    """These answer nil -- the blocking ones after waiting out their timeout -- rather than WRONGTYPE."""
+    assert raw_command(mixed, *args) is None
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("blpop", "str", 0.1),
+        ("blmove", "str", "list", "left", "right", 0.1),
+        ("lmove", "str", "list", "left", "right"),
+        ("rpoplpush", "str", "list"),
+        ("zmpop", 1, "str", "min"),
+        ("lpop", "str"),
+        ("lrange", "str", 0, -1),
+    ],
+)
+def test_pops_that_still_check(mixed: ClientType, args: tuple):
+    """BLPOP checks where BRPOP does not, and ZMPOP where BZMPOP does not."""
+    with pytest.raises(Exception, match=WRONGTYPE):
+        raw_command(mixed, *args)
+
+
+def test_a_wrong_type_is_only_passed_over_not_given_up_on(mixed: ClientType):
+    """The keys that can be popped from still are, whichever side of the bad key they are on."""
+    assert raw_command(mixed, "brpop", "str", "list", 0.1) == [b"list", b"b"]
+    assert raw_command(mixed, "brpop", "list", "str", 0.1) == [b"list", b"a"]
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("zdiff", 2, "set", "zset"),
+        ("zunion", 2, "set", "zset"),
+        ("zintercard", 2, "set", "zset"),
+        ("zinterstore", "dest", 2, "set", "zset"),
+        ("zunionstore", "dest", 2, "set", "zset"),
+        ("zdiffstore", "dest", 2, "set", "zset"),
+    ],
+)
+def test_sorted_set_aggregates_refuse_a_plain_set(mixed: ClientType, args: tuple):
+    """Redis reads a plain set as a sorted set scoring every member 1; KiviDB never does."""
+    with pytest.raises(Exception, match=WRONGTYPE):
+        raw_command(mixed, *args)

--- a/test/test_mixins/test_list_commands.py
+++ b/test/test_mixins/test_list_commands.py
@@ -553,6 +553,7 @@ def test_brpop_single_key(r: ClientType):
     assert r.brpop("foo", timeout=1) == resp_conversion(r, [b"foo", b"two"], (b"foo", b"two"))
 
 
+@pytest.mark.unsupported_server_types("kividb")
 def test_brpop_wrong_type(r: ClientType):
     r.set("foo", "bar")
     with pytest.raises(Exception) as ctx:
@@ -572,6 +573,7 @@ def test_brpoplpush_multi_keys(r: ClientType):
     assert r.lrem("bar", -1, "two") == 1
 
 
+@pytest.mark.unsupported_server_types("kividb")
 def test_brpoplpush_wrong_type(r: ClientType):
     r.set("foo", "bar")
     r.rpush("list", "element")

--- a/test/test_mixins/test_set_commands.py
+++ b/test/test_mixins/test_set_commands.py
@@ -85,6 +85,7 @@ def test_sdiff_empty(r: ClientType):
     assert set(r.sdiff("foo")) == set()
 
 
+@pytest.mark.unsupported_server_types("kividb")
 def test_sdiff_wrong_type(r: ClientType):
     r.zadd("foo", {"member": 1})
     r.sadd("bar", "member")
@@ -129,6 +130,7 @@ def test_sinter_bytes_keys(r: ClientType):
     assert set(r.sinter(foo)) == {b"member1", b"member2"}
 
 
+@pytest.mark.unsupported_server_types("kividb")
 def test_sinter_wrong_type(r: ClientType):
     r.zadd("foo", {"member": 1})
     r.sadd("bar", "member")
@@ -316,6 +318,7 @@ def test_sunion(r: ClientType):
     assert set(r.sunion("foo", "bar")) == {b"member1", b"member2", b"member3"}
 
 
+@pytest.mark.unsupported_server_types("kividb")
 def test_sunion_wrong_type(r: ClientType):
     r.zadd("foo", {"member": 1})
     r.sadd("bar", "member")
@@ -435,6 +438,7 @@ def test_sintercard_negative_limit(r: ClientType, real_server_details):
     assert expected in str(ctx.value)
 
 
+@pytest.mark.unsupported_server_types("kividb")
 @pytest.mark.supported_server_versions(min_redis_ver="7")
 def test_sintercard_wrong_type(r: ClientType):
     r.zadd("foo", {"member": 1})

--- a/test/test_mixins/test_sortedset_commands.py
+++ b/test/test_mixins/test_sortedset_commands.py
@@ -1015,6 +1015,7 @@ def test_zunionstore_nan_to_zero_ordering(r: ClientType):
     assert r.zscore("baz", "e1") == 0.0
 
 
+@pytest.mark.unsupported_server_types("kividb")
 def test_zunionstore_mixed_set_types(r: ClientType):
     # No score, redis will use 1.0.
     r.sadd("foo", "one")
@@ -1056,7 +1057,7 @@ def test_zinterstore(r: ClientType):
     assert r.zrange("baz", 0, -1, withscores=True) == resp_conversion_from_resp2(r, [(b"one", 2), (b"two", 4)])
 
 
-@pytest.mark.unsupported_server_types("dragonfly")
+@pytest.mark.unsupported_server_types("dragonfly", "kividb")
 def test_zinterstore_mixed_set_types(r: ClientType):
     r.sadd("foo", "one")
     r.sadd("foo", "two")


### PR DESCRIPTION
Step 5 of #568 — the type checks KiviDB does not make, the one it makes that redis does not, and two
server-agnostic crashes the comparison uncovered.

### What KiviDB does

**Multi-key set operations read a wrongly typed key as an empty set.** `SDIFF`, `SINTER`, `SUNION`,
`SINTERCARD` and the three STORE forms all do it; the single-key ones (`SMEMBERS`, `SCARD`, `SADD`, `SPOP`,
`SMOVE`, …) still answer WRONGTYPE.

```
SDIFF str set   -> []        SUNION str set -> [m]      SINTERCARD 2 str set -> 0
```

**Some pops pass over a wrongly typed key; others do not.** The split is not a rule, it is per command, and
fakeredis now follows it exactly:

| passes over it (answers nil, after blocking) | still answers WRONGTYPE |
|---|---|
| `BRPOP`, `BRPOPLPUSH`, `BZPOPMIN`, `BZPOPMAX`, `BZMPOP`, `BLMPOP`, `LMPOP` | `BLPOP`, `BLMOVE`, `LMOVE`, `RPOPLPUSH`, `ZMPOP`, `LPOP`, `LRANGE` |

Passing over is not giving up: `BRPOP str list 0.1` still pops from `list`.

**The sorted set aggregates are stricter than redis.** `ZDIFF`, `ZUNION`, `ZINTERCARD` and the STORE forms
refuse a plain set, where redis reads one as a sorted set scoring every member 1.

### Two crashes fixed on the way, for every server type

Both are pre-existing fakeredis bugs, found by diffing against a real server rather than by the suite:

- `BZPOPMIN`, `BZPOPMAX`, `BZMPOP` and `ZMPOP` on a key of the wrong type raised a bare Python
  `AttributeError: 'bytes' object has no attribute 'get'` — it reached the caller as an exception no redis
  client can handle. They answer WRONGTYPE now.
- `XADD` on a key of the wrong type raised `AttributeError: 'bytes' object has no attribute 'add'`. It takes an
  untyped `Key()` so that `NOMKSTREAM` can tell a missing key from an empty stream, which left nothing to make
  the check; it is now made by hand, after the arity check, which is the order both redis and KiviDB use.

### The mechanism

`Key` grows `empty_on_wrongtype`, a list of server types that read a wrongly typed key there as an empty one,
so the multi-key set commands declare the divergence in their signature rather than in their body. The pops
take a `check_type` flag, set per command.

### Tests

`test/test_kividb/test_type_checks.py` covers the whole matrix above against both the fake and the real server.
Eight redis-flavoured tests are marked `unsupported_server_types("kividb")` — including
`test_brpoplpush_wrong_type`, which would otherwise **hang**: `brpoplpush` defaults to `timeout=0`, and passing
over the wrongly typed source means blocking forever, on the real server as much as on the fake one.

Set, list, sorted set, stream and `test_kividb` suites against a real KiviDB: **80 failed, 1302 passed**, and
every remaining failure is on the real side only — fakeredis matches KiviDB on everything these files exercise
that this step covers. What is left belongs to later steps: emptied collections keeping their key, NaN scores,
blocking-timeout and SINTERCARD wording, `LINSERT`/`LMOVE` keyword tolerance, and the stream divergences.

`-m fake` in KiviDB mode: 2152 passed, 0 failed.

Full suite against a real **redis:8.4.0**: 5011 passed, 2 failed — `test_pubsub_shardnumsub[Strict3]`, the subscription leak that fails on master too, and one `FailedHealthCheck` flake in `test_hypothesis/test_zset.py` that passes on three consecutive re-runs. No regression.

<!--STACK-->
### This PR is part of a stack

Work on #568, split into reviewable steps. Each branches off the one above it, so they merge in order;
the diff shown here is only this step's own changes.

| PR | Branch | What it covers |
|---|--------|----------------|
| #569 | `kividb/01-server-type` | The `kividb` server type, and detecting a real KiviDB from `INFO` |
| #570 | `kividb/02-harness` | `test-kividb.yml`, and the suites that cannot apply to KiviDB |
| #571 | `kividb/03-command-surface` | Which commands KiviDB has, and its bare unknown-command error |
| #572 | `kividb/04-errors` | The permissive argument parsing of its sorted set commands |
| #573 | `kividb/05-type-checks` | The type checks it skips, the one it adds, and two crash fixes |

More steps follow: the remaining behavioural divergences the measurement in #570 turned up, then
`docs/kividb-support.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
