### PR TITLE
ci: cover dragonfly in the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       max-parallel: 8
       fail-fast: false
       matrix:
-        redis-image:
+        server-image:
           - "redis:8.8"
           - "valkey/valkey:9.1"
           - "redis:7.4.8"
@@ -53,39 +53,44 @@ jobs:
           - python-version: "3.10"
             redis-py: "8.1.0"
           - python-version: "3.14"
-            redis-image: "redis:8.8"
+            server-image: "redis:8.8"
             redis-py: "7.4.0"
             install-extras: false
             coverage: false
         include:
           - python-version: "3.10"
-            redis-image: "redis:8.8"
+            server-image: "redis:8.8"
             redis-py: "4.6.0"
             install-extras: false
             coverage: false
           - python-version: "3.10"
-            redis-image: "redis:8.8"
+            server-image: "redis:8.8"
             redis-py: "5.3.1"
             install-extras: false
             coverage: false
           - python-version: "3.14"
-            redis-image: "redis/redis-stack-server:6.2.6-v20"
+            server-image: "redis/redis-stack-server:6.2.6-v20"
             redis-py: "8.1.0"
             install-extras: true
           - python-version: "3.14"
-            redis-image: "redis/redis-stack-server:7.4.0-v8"
+            server-image: "redis/redis-stack-server:7.4.0-v8"
             redis-py: "8.1.0"
             install-extras: true
           - python-version: "3.14"
-            redis-image: "redis:8.8"
+            server-image: "redis:8.8"
             redis-py: "8.1.0"
             install-extras: true
             coverage: true
+          - python-version: "3.14"
+            server-image: "docker.dragonflydb.io/dragonflydb/dragonfly:v1.40.2"
+            redis-py: "8.1.0"
+            install-extras: true
+            coverage: false
     permissions:
       pull-requests: write
     services:
       keydb:
-        image: ${{ matrix.redis-image }}
+        image: ${{ matrix.server-image }}
         ports:
           - 6390:6379
         options: >-
@@ -95,7 +100,7 @@ jobs:
           --health-retries 5
     name: >
       tests
-      ${{ matrix.redis-image }},
+      ${{ matrix.server-image }},
       py${{ matrix.python-version }},redis-py:${{ matrix.redis-py }},
       cov:${{ matrix.coverage }},extra:${{matrix.install-extras}}
     outputs:


### PR DESCRIPTION
Adds a dragonfly leg to the `include` list — python 3.14, redis-py 8.1.0, all extras — pinned to v1.40.2 rather than latest so a matrix failure points at a known build. The image is the one test-dragonfly.yml already uses and listens on 6379, so the existing service block covers it unchanged.

Since the matrix now names a server that is not redis, `redis-image` becomes `server-image`.

Verified against a real dragonfly v1.40.2: the workflow's own selection (`-m "not slow and not tcp_server"`, all extras) gives 3499 passed, 2 failed in 33s. Both failures are test_eval_returns_resp3_shapes_a_script_built, real-side only — dragonfly has no RESP3 `double`/`big_number` Lua conversion, which fakeredis does not yet emulate. That is left for a follow-up.


